### PR TITLE
Much faster and more efficient contrastive pretraining with torch.compile and amp

### DIFF
--- a/pretraining/trainers/train.py
+++ b/pretraining/trainers/train.py
@@ -35,6 +35,10 @@ from models import create_model
 from util.visualization import Visualizer
 from util.util import save_tensor
 
+import torch.backends.cudnn as cudnn
+
+cudnn.benchmark = True  # our input sizes are always fixed
+
 # -------------------------------
 # Load experiment settings
 # -------------------------------
@@ -189,6 +193,12 @@ for epoch in range(
             model.data_dependent_initialize(data)
             model.setup(opt)  # Load and print networks, create schedulers
             model.train()
+
+            # Compile:
+            print('Compiling models...')
+            model.netG = torch.compile(model.netG, mode="default")
+            if hasattr(model, "netF"):
+                model.netF = torch.compile(model.netF, mode="default")
 
         # Print info every print_freq iterations
         verbose = (total_iters % opt.print_freq == 0)


### PR DESCRIPTION
Wrapping the NCE losses in torch.compile and using AMP cuts training time for the ICLR version of the model from ~6 days to ~30 hours with concomitantly lower memory usage as well.

(Why didn't I do this 1.5 years ago?)