### PR TITLE
Add new, bigger, and better pretrained model (+ support for loading from HF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ![Highlight collage](https://www.neeldey.com/files/anatomix_github_highlight.png)
 
+> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+
+> **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [DropGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
+
 `anatomix` is a general-purpose feature extractor for 3D volumes. For any new biomedical dataset or task,
 - Its out-of-the-box features are invariant to most forms of nuisance imaging variation.
 - Its out-of-the-box weights are a good initialization for finetuning when given limited annotations.
@@ -25,11 +29,21 @@ volumes to learn approximate appearance invariance and pose
 equivariance for images with randomly sampled biomedical shape configurations with
 random intensities and artifacts.
 
-> Note: This repo was recently bumped up to PyTorch 2.8.0 and Python 3.11. If you find any bugs or changes in performance, please open an issue.
-
 ## Load weights for inference / feature extraction / finetuning
 
 `anatomix` is just a pretrained UNet! Use it for whatever you like.
+
+Pull the model and weights from HuggingFace Hub:
+
+```python
+from anatomix.model.load_from_hf import load_from_hf
+
+model = load_from_hf("anatomix")          # 6M params. ICLR2025 version of the pretrained model
+# model = load_from_hf("anatomix+brains") # 6M params. Brain label augmented ICLR2025 version of the pretrained model
+# model = load_from_hf("anatomix-dev")    # 36M params. Experimental model. More parameters, better features. Give it a shot.
+```
+
+Or load a local checkpoint:
 
 ```python
 import torch
@@ -50,7 +64,7 @@ model.load_state_dict(
 
 See how to use it on real data for feature extraction or registration in [this tutorial](https://colab.research.google.com/drive/1shivu4GtUoiDzDrE9RKD1RuEm3OqXJuD?usp=sharing). Or if you want to finetune for your own task, check out [this tutorial](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing) instead.
 
-(If your task involves brains, you might benefit by using the `anatomix+brains.pth` weights instead, where we synthesize training volumes using both our synthetic label ensembles and real brain labels.)
+(If your task involves brains, you might benefit by using the `anatomix+brains` (6M) or `anatomix-dev` (36M) weights instead.)
 
 ## Install dependencies:
 
@@ -68,7 +82,7 @@ Or install the dependencies manually:
 ```
 conda create -n anatomix python=3.11
 conda activate anatomix
-pip install numpy nibabel scipy scikit-image nilearn h5py matplotlib torch==2.8.0 tensorboard tqdm monai torchio SimpleITK natsort
+pip install numpy nibabel scipy scikit-image nilearn h5py matplotlib torch==2.8.0 tensorboard tqdm monai torchio SimpleITK natsort huggingface_hub
 ```
 
 ## Folder organization

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 #### [Colab Tutorial: 3D Feature Extraction & 3D Multimodal Registration](https://colab.research.google.com/drive/1shivu4GtUoiDzDrE9RKD1RuEm3OqXJuD?usp=sharing)
 #### [Colab Tutorial: Finetune anatomix for 3D Few-shot Segmentation with MONAI](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing)
 
-![Highlight collage](https://www.neeldey.com/files/anatomix_github_highlight.png)
-
-> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode (e.g. on whole body CT), it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
 
 > **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [DropGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
+
+![Highlight collage](https://www.neeldey.com/files/anatomix_github_highlight.png)
 
 `anatomix` is a general-purpose feature extractor for 3D volumes. For any new biomedical dataset or task,
 - Its out-of-the-box features are invariant to most forms of nuisance imaging variation.
@@ -40,10 +40,14 @@ from anatomix.model.load_from_hf import load_from_hf
 
 model = load_from_hf("anatomix")          # 6M params. ICLR2025 version of the pretrained model
 # model = load_from_hf("anatomix+brains") # 6M params. Brain label augmented ICLR2025 version of the pretrained model
-# model = load_from_hf("anatomix-dev")    # 36M params. Experimental model. More parameters, better features. Give it a shot.
 ```
 
-Or load a local checkpoint:
+Or **NEW** experimental model architecture and weights available here:
+```python
+model = load_from_hf("anatomix-dev")      # 36M params. Experimental model. More parameters, better features. Give it a shot.
+```
+
+Or just load a local checkpoint:
 
 ```python
 import torch
@@ -56,6 +60,9 @@ model = Unet(
     num_downs=4,  # number of downsampling layers
     ngf=16,  # channel multiplier
 )
+
+# model = torch.compile(model)  # add if using a compiled pretrained model such as `anatomix-dev`
+
 model.load_state_dict(
     torch.load("./model-weights/anatomix.pth"),
     strict=True,

--- a/anatomix/model/load_from_hf.py
+++ b/anatomix/model/load_from_hf.py
@@ -1,0 +1,62 @@
+"""Load anatomix Unet weights from the HuggingFace Hub."""
+import torch
+from huggingface_hub import hf_hub_download
+
+from anatomix.model.network import Unet
+
+
+DEFAULT_REPO = "neeldey/anatomix"
+
+# Variant name -> kwargs passed to Unet.__init__. Add new entries here when a
+# new variant is published to the Hub. Any kwarg accepted by Unet is allowed.
+ANATOMIX_VARIANTS = {
+    "anatomix": {
+        "unet_kwargs": dict(
+            dimension=3, input_nc=1, output_nc=16, num_downs=4, ngf=16,
+        ),
+    },
+    "anatomix+brains": {
+        "unet_kwargs": dict(
+            dimension=3, input_nc=1, output_nc=16, num_downs=4, ngf=16,
+        ),
+    },
+    "anatomix-dev": {
+        "unet_kwargs": dict(
+            dimension=3, input_nc=1, output_nc=16, num_downs=5, ngf=20,
+            norm="instance", pooling="Avg", interp="trilinear",
+        ),
+    },
+}
+
+
+def _load_handling_compile(model, state_dict):
+    """Load `state_dict` into `model`, transparently handling weights saved
+    from a `torch.compile()`-wrapped model (whose keys carry an `_orig_mod.`
+    prefix). The compiled wrapper is applied before loading so the structures
+    match."""
+    if state_dict and next(iter(state_dict)).startswith("_orig_mod."):
+        model = torch.compile(model)
+    model.load_state_dict(state_dict, strict=True)
+    return model
+
+
+def load_from_hf(
+    variant,
+    repo_id=DEFAULT_REPO,
+    revision=None,
+    map_location="cpu",
+):
+    """Download `<variant>.pth` from `repo_id` on the HuggingFace Hub and
+    return a Unet instantiated with the registered kwargs and weights loaded.
+    """
+    if variant not in ANATOMIX_VARIANTS:
+        raise ValueError(
+            f"Unknown variant {variant!r}. "
+            f"Known: {sorted(ANATOMIX_VARIANTS)}"
+        )
+    weights_path = hf_hub_download(
+        repo_id, f"{variant}.pth", revision=revision,
+    )
+    state_dict = torch.load(weights_path, map_location=map_location)
+    model = Unet(**ANATOMIX_VARIANTS[variant]["unet_kwargs"])
+    return _load_handling_compile(model, state_dict)

--- a/anatomix/registration/README.md
+++ b/anatomix/registration/README.md
@@ -4,6 +4,8 @@
 
 ![Qualitative registration collage](https://www.neeldey.com/files/qualitative-registration-v2.png)
 
+> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+
 The demo script in this folder extracts pretrained network features from input
 volumes and runs a registration solver on the features to align volumes
 across imaging modalities.
@@ -18,12 +20,14 @@ clip the CT values to [-450, 450] HU and register MRI volumes to CT volumes.
 
 Example usage to register `moving.nii.gz` to `fixed.nii.gz` (with optional
 registration masks `moving_mask.nii.gz` and `fixed.nii.gz`), assuming that 
-fixed is a CT volume:
+fixed is a CT volume.
+
+Pulling weights from the HuggingFace Hub:
 ```bash
 python run_convex_adam_with_network_feats.py \
     --fixed fixed.nii.gz \
     --moving moving.nii.gz \
-    --ckpt_path ../../model-weights/anatomix.pth \
+    --hf_variant anatomix \
     --exp_name demo \
     --use_mask \
     --path_mask_fixed fixed_mask.nii.gz \
@@ -32,11 +36,43 @@ python run_convex_adam_with_network_feats.py \
     --fixed_maxclip 450
 ```
 
+Or using a local checkpoint. When loading a local `.pth`, the U-Net
+architecture flags must be set to match the checkpoint that was saved.
+The values below are the defaults for the published `anatomix` and
+`anatomix+brains` weights (so they could be omitted), but they're shown
+explicitly here because non-default checkpoints will need to override them:
+```bash
+python run_convex_adam_with_network_feats.py \
+    --fixed fixed.nii.gz \
+    --moving moving.nii.gz \
+    --ckpt_path ../../model-weights/anatomix.pth \
+    --num_downs 4 \
+    --ngf 16 \
+    --output_nc 16 \
+    --norm batch \
+    --interp nearest \
+    --pooling Max \
+    --exp_name demo \
+    --use_mask \
+    --path_mask_fixed fixed_mask.nii.gz \
+    --path_mask_moving moving_mask.nii.gz \
+    --fixed_minclip -450 \
+    --fixed_maxclip 450
+```
+
+Exactly one of `--ckpt_path` or `--hf_variant` must be provided. The
+architecture flags (`--num_downs`, `--ngf`, `--output_nc`, `--norm`,
+`--interp`, `--pooling`) are only consulted with `--ckpt_path`; for
+`--hf_variant`, kwargs come from the variant registry on the Hub side.
+
 Entire CLI:
 ```bash
 $ python run_convex_adam_with_network_feats.py -h
 
-usage: run_convex_adam_with_network_feats.py [-h] --fixed FIXED --moving MOVING --exp_name EXP_NAME --ckpt_path CKPT_PATH
+usage: run_convex_adam_with_network_feats.py [-h] --fixed FIXED --moving MOVING --exp_name EXP_NAME
+                                             (--ckpt_path CKPT_PATH | --hf_variant HF_VARIANT)
+                                             [--num_downs NUM_DOWNS] [--ngf NGF] [--output_nc OUTPUT_NC]
+                                             [--norm NORM] [--interp INTERP] [--pooling POOLING]
                                              [--result_path RESULT_PATH] [--lambda_weight LAMBDA_WEIGHT]
                                              [--grid_sp GRID_SP] [--disp_hw DISP_HW] [--selected_niter SELECTED_NITER]
                                              [--selected_smooth SELECTED_SMOOTH] [--grid_sp_adam GRID_SP_ADAM] [--no-ic]
@@ -54,7 +90,24 @@ options:
   --moving MOVING       Path to the moving image *.nii.gz file (required).
   --exp_name EXP_NAME   Experiment name for logging and output purposes (required).
   --ckpt_path CKPT_PATH
-                        Path to the checkpoint for loading the model (required).
+                        Path to a local .pth model checkpoint. Mutually exclusive with --hf_variant.
+  --hf_variant HF_VARIANT
+                        HuggingFace Hub variant to download from neeldey/anatomix
+                        (e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').
+                        Mutually exclusive with --ckpt_path.
+  --num_downs NUM_DOWNS
+                        Number of downsampling layers in the U-Net. Default 4.
+                        Only used with --ckpt_path.
+  --ngf NGF             Channel multiplier for the U-Net. Default 16.
+                        Only used with --ckpt_path.
+  --output_nc OUTPUT_NC
+                        Number of output feature channels. Default 16.
+                        Only used with --ckpt_path.
+  --norm NORM           Normalization type ('batch', 'instance', 'none'). Default 'batch'.
+                        Only used with --ckpt_path.
+  --interp INTERP       Decoder upsampling mode ('nearest' or 'trilinear'). Default 'nearest'.
+                        Only used with --ckpt_path.
+  --pooling POOLING     Pooling type ('Max' or 'Avg'). Default 'Max'. Only used with --ckpt_path.
   --result_path RESULT_PATH
                         Directory to save the output results. Default current directory.
   --lambda_weight LAMBDA_WEIGHT

--- a/anatomix/registration/convex_adam_utils.py
+++ b/anatomix/registration/convex_adam_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -8,28 +10,70 @@ import time
 from monai.inferers import sliding_window_inference
 
 from anatomix.model.network import Unet
+from anatomix.model.load_from_hf import load_from_hf, _load_handling_compile
 
 
-def load_model(ckpt_path):
+def load_model(
+    ckpt_path=None,
+    hf_variant=None,
+    *,
+    num_downs=4,
+    ngf=16,
+    output_nc=16,
+    norm="batch",
+    interp="nearest",
+    pooling="Max",
+):
     """
-    Load a pretrained U-Net model from a checkpoint file.
-    
+    Load a pretrained U-Net model.
+
+    Exactly one of `ckpt_path` or `hf_variant` must be provided.
+
     Parameters
     ----------
-    ckpt_path : str
-        Path to the model checkpoint file.
-        
+    ckpt_path : str, optional
+        Path to a local .pth checkpoint.
+    hf_variant : str, optional
+        Variant name to download from the HuggingFace Hub
+        (see `anatomix.model.load_from_hf.ANATOMIX_VARIANTS`).
+    num_downs, ngf, output_nc, norm, interp, pooling
+        Architecture kwargs forwarded to `Unet` when loading from
+        `ckpt_path`. Ignored when `hf_variant` is used (kwargs come from
+        the variant registry).
+
     Returns
     -------
     model : torch.nn.Module
         Loaded U-Net model in frozen evaluation mode.
     """
+    if (ckpt_path is None) == (hf_variant is None):
+        raise ValueError(
+            "Provide exactly one of `ckpt_path` or `hf_variant`."
+        )
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = Unet(3, 1, 16, 4, ngf=16).to(device)
+
+    if hf_variant is not None:
+        model = load_from_hf(hf_variant)
+    elif ckpt_path == "scratch":
+        raise ValueError(
+            "'scratch' is not supported for registration; "
+            "registration requires pretrained weights."
+        )
+    else:
+        if not os.path.isfile(ckpt_path):
+            raise FileNotFoundError(
+                f"Checkpoint file not found: {ckpt_path}"
+            )
+        model = Unet(
+            3, 1, output_nc, num_downs, ngf=ngf, norm=norm,
+            interp=interp, pooling=pooling,
+        )
+        model = _load_handling_compile(
+            model, torch.load(ckpt_path, map_location="cpu"),
+        )
 
     model.to(device)
-    model.load_state_dict(torch.load(ckpt_path), strict=True)
-        
     model.eval()
     return model
 

--- a/anatomix/registration/run_convex_adam_with_network_feats.py
+++ b/anatomix/registration/run_convex_adam_with_network_feats.py
@@ -25,6 +25,7 @@ warnings.filterwarnings("ignore")
 # coupled convex optimisation with adam instance optimisation
 def convex_adam(
     ckpt_path,
+    hf_variant,
     expname,
     lambda_weight,
     grid_sp,
@@ -47,6 +48,12 @@ def convex_adam(
     fixed_seg=None,
     moving_seg=None,
     downscale_feat_scalar=0.1,
+    num_downs=4,
+    ngf=16,
+    output_nc=16,
+    norm="batch",
+    interp="nearest",
+    pooling="Max",
 ):
     """
     This function first extracts anatomix and MIND features from the input
@@ -55,8 +62,12 @@ def convex_adam(
 
     Parameters
     ----------
-    ckpt_path : str
-        Path to the model checkpoint.
+    ckpt_path : str or None
+        Path to a local model checkpoint (.pth). Mutually exclusive with
+        `hf_variant`.
+    hf_variant : str or None
+        Variant name to download from the HuggingFace Hub. Mutually
+        exclusive with `ckpt_path`.
     expname : str
         Name of the experiment for logging and output file naming.
     lambda_weight : float
@@ -112,10 +123,11 @@ def convex_adam(
     
     # load model:
     print('Loading model')
-    if not os.path.isfile(ckpt_path):
-        raise FileNotFoundError(f"Checkpoint file not found: {ckpt_path}")
-    
-    model = load_model(ckpt_path)
+    model = load_model(
+        ckpt_path=ckpt_path, hf_variant=hf_variant,
+        num_downs=num_downs, ngf=ngf, output_nc=output_nc,
+        norm=norm, interp=interp, pooling=pooling,
+    )
     
     # load images:
     affine_mtx = nib.load(fixed_image).affine
@@ -331,9 +343,47 @@ if __name__=="__main__":
         "--exp_name", type=str, required=True,
         help="Experiment name for logging and output purposes (required)."
     )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--ckpt_path", type=str, default=None,
+        help="Path to a local .pth model checkpoint."
+    )
+    src.add_argument(
+        "--hf_variant", type=str, default=None,
+        help="HuggingFace Hub variant to download from neeldey/anatomix "
+             "(e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev')."
+    )
+    # Unet architecture kwargs. Only used with --ckpt_path; ignored for
+    # --hf_variant (kwargs come from the variant registry).
     parser.add_argument(
-        "--ckpt_path", type=str, required=True,
-        help="Path to the checkpoint for loading the model (required)."
+        "--num_downs", type=int, default=4,
+        help="Number of downsampling layers in the U-Net. Default 4. "
+             "Only used with --ckpt_path."
+    )
+    parser.add_argument(
+        "--ngf", type=int, default=16,
+        help="Channel multiplier for the U-Net. Default 16. "
+             "Only used with --ckpt_path."
+    )
+    parser.add_argument(
+        "--output_nc", type=int, default=16,
+        help="Number of output feature channels. Default 16. "
+             "Only used with --ckpt_path."
+    )
+    parser.add_argument(
+        "--norm", type=str, default="batch",
+        help="Normalization type ('batch', 'instance', 'none'). "
+             "Default 'batch'. Only used with --ckpt_path."
+    )
+    parser.add_argument(
+        "--interp", type=str, default="nearest",
+        help="Decoder upsampling mode ('nearest' or 'trilinear'). "
+             "Default 'nearest'. Only used with --ckpt_path."
+    )
+    parser.add_argument(
+        "--pooling", type=str, default="Max",
+        help="Pooling type ('Max' or 'Avg'). Default 'Max'. "
+             "Only used with --ckpt_path."
     )
     parser.add_argument(
         "--result_path", type=str, default='./',
@@ -418,6 +468,7 @@ if __name__=="__main__":
 
     convex_adam(
         args.ckpt_path,
+        args.hf_variant,
         args.exp_name,
         args.lambda_weight,
         args.grid_sp,
@@ -439,4 +490,10 @@ if __name__=="__main__":
         args.warp_seg,
         args.path_seg_fixed,
         args.path_seg_moving,
+        num_downs=args.num_downs,
+        ngf=args.ngf,
+        output_nc=args.output_nc,
+        norm=args.norm,
+        interp=args.interp,
+        pooling=args.pooling,
     )

--- a/anatomix/segmentation/README.md
+++ b/anatomix/segmentation/README.md
@@ -2,6 +2,10 @@
 
 ### [Colab tutorial on how to prepare data and finetune for 3D segmentation with anatomix and MONAI](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing)
 
+> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+
+> **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [DropGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
+
 Using only a few annotated volumes (3, 3, and 1 for the datasets in the screenshot below), 
 we can finetune the pretrained anatomix weights to significantly improve segmentation
 performance:
@@ -43,31 +47,70 @@ sets in the `train_segmentation.py` scripts are used for model selection.
 
 Once you have your data organized, start a finetuning run for `NCLASSES`-segmentation 
 (e.g., if you have 3 organs and background, `NCLASSES=3`) with `NVOLS` annotated 
-finetuning volumes from `imagesTr` and `labelsTr` with our pretrained weights as:
-```bash
-python train_segmentation.py 
---dataset ./dataset/ \
---n_classes NCLASSES \
---train_amount NVOLS \
---pretrained_ckpt ../../model-weights/anatomix.pth
-```
+finetuning volumes from `imagesTr` and `labelsTr` with our pretrained weights.
 
-To train from scratch / random initialization instead:
+Pulling weights from HuggingFace Hub:
 ```bash
 python train_segmentation.py \
 --dataset ./dataset/ \
 --n_classes NCLASSES \
 --train_amount NVOLS \
---pretrained_ckpt scratch
+--hf_variant anatomix
 ```
+
+Or using a local checkpoint. When loading a local `.pth`, the U-Net
+architecture flags must be set to match the checkpoint that was saved.
+The values below are the defaults for the published `anatomix` and
+`anatomix+brains` weights (so they could be omitted), but they're shown
+explicitly here because non-default checkpoints will need to override them:
+```bash
+python train_segmentation.py \
+--dataset ./dataset/ \
+--n_classes NCLASSES \
+--train_amount NVOLS \
+--pretrained_ckpt ../../model-weights/anatomix.pth \
+--num_downs 4 \
+--ngf 16 \
+--output_nc 16 \
+--norm batch \
+--interp nearest \
+--pooling Max
+```
+
+To train from scratch / random initialization instead (the same
+architecture flags configure the freshly-initialized U-Net):
+```bash
+python train_segmentation.py \
+--dataset ./dataset/ \
+--n_classes NCLASSES \
+--train_amount NVOLS \
+--pretrained_ckpt scratch \
+--num_downs 4 \
+--ngf 16 \
+--output_nc 16 \
+--norm batch \
+--interp nearest \
+--pooling Max
+```
+
+Exactly one of `--pretrained_ckpt` or `--hf_variant` must be provided. The
+architecture flags (`--num_downs`, `--ngf`, `--output_nc`, `--norm`,
+`--interp`, `--pooling`) are only consulted with `--pretrained_ckpt` (and
+the `'scratch'` sentinel); for `--hf_variant`, kwargs come from the variant
+registry.
 
 Logs and checkpoints are saved in `finetuning_runs/checkpoints/` and `finetuning_runs/runs/`, respectively.
 
 See full CLI below:
 ```
 $ python train_segmentation.py -h
-usage: train_segmentation.py [-h] [--dataset DATASET] [--n_epochs N_EPOCHS] [--n_iters_per_epoch N_ITERS_PER_EPOCH] [--n_classes N_CLASSES] [--val_interval VAL_INTERVAL] [--lr LR]
-                             [--crop_size CROP_SIZE] [--batch_size BATCH_SIZE] [--train_amount TRAIN_AMOUNT] [--pretrained_ckpt PRETRAINED_CKPT] [--exp_name EXP_NAME]
+usage: train_segmentation.py [-h] [--dataset DATASET] [--n_epochs N_EPOCHS] [--n_iters_per_epoch N_ITERS_PER_EPOCH]
+                             [--n_classes N_CLASSES] [--val_interval VAL_INTERVAL] [--lr LR]
+                             [--crop_size CROP_SIZE] [--batch_size BATCH_SIZE] [--train_amount TRAIN_AMOUNT]
+                             (--pretrained_ckpt PRETRAINED_CKPT | --hf_variant HF_VARIANT)
+                             [--num_downs NUM_DOWNS] [--ngf NGF] [--output_nc OUTPUT_NC]
+                             [--norm NORM] [--interp INTERP] [--pooling POOLING]
+                             [--exp_name EXP_NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -87,6 +130,24 @@ optional arguments:
   --train_amount TRAIN_AMOUNT
                         No. of training samples to use for few-shot training
   --pretrained_ckpt PRETRAINED_CKPT
-                        Default points to model weights path. Set to 'scratch' for random initialization
+                        Path to a local .pth checkpoint, or 'scratch' for random initialization.
+                        Mutually exclusive with --hf_variant.
+  --hf_variant HF_VARIANT
+                        HuggingFace Hub variant to download from neeldey/anatomix
+                        (e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').
+                        Mutually exclusive with --pretrained_ckpt.
+  --num_downs NUM_DOWNS
+                        Number of downsampling layers in the U-Net. Default 4.
+                        Only used with --pretrained_ckpt.
+  --ngf NGF             Channel multiplier for the U-Net. Default 16.
+                        Only used with --pretrained_ckpt.
+  --output_nc OUTPUT_NC
+                        Number of output feature channels of the U-Net. Default 16.
+                        Only used with --pretrained_ckpt.
+  --norm NORM           Normalization type ('batch', 'instance', 'none'). Default 'batch'.
+                        Only used with --pretrained_ckpt.
+  --interp INTERP       Decoder upsampling mode ('nearest' or 'trilinear'). Default 'nearest'.
+                        Only used with --pretrained_ckpt.
+  --pooling POOLING     Pooling type ('Max' or 'Avg'). Default 'Max'. Only used with --pretrained_ckpt.
   --exp_name EXP_NAME   Prefix to attach to training logs in folder and file names
 ```

--- a/anatomix/segmentation/segmentation_utils.py
+++ b/anatomix/segmentation/segmentation_utils.py
@@ -5,6 +5,13 @@ from monai.networks.blocks import UnetOutBlock
 from glob import glob
 from natsort import natsorted
 
+from anatomix.model.network import Unet
+from anatomix.model.load_from_hf import (
+    ANATOMIX_VARIANTS,
+    load_from_hf,
+    _load_handling_compile,
+)
+
 from monai.transforms import (
     ScaleIntensityd,
     Compose,
@@ -21,49 +28,91 @@ from monai.transforms import (
     EnsureChannelFirstd,
 )
 
-from anatomix.model.network import Unet
-
 
 # -----------------------------------------------------------------------------
 # Loading pretrained model
 
 
-def load_model(pretrained_ckpt, n_classes, device):
+def load_model(
+    n_classes,
+    device,
+    *,
+    ckpt_path=None,
+    hf_variant=None,
+    num_downs=4,
+    ngf=16,
+    output_nc=16,
+    norm="batch",
+    interp="nearest",
+    pooling="Max",
+):
     """
     Load and configure a U-Net model for semantic segmentation.
-    
-    This function creates a U-Net model and optionally loads pretrained weights.
-    It adds a final output layer for the specified number of segmentation classes.
-    
+
+    This function creates a U-Net model and optionally loads pretrained
+    weights. It adds a final output layer for the specified number of
+    segmentation classes.
+
+    Exactly one of `ckpt_path` or `hf_variant` must be provided. Pass
+    `ckpt_path='scratch'` for random initialization.
+
     Parameters
     ----------
-    pretrained_ckpt : str
-        Path to pretrained model checkpoint, or 'scratch' for random initialization
     n_classes : int
-        Number of segmentation classes (excluding background)
+        Number of segmentation classes (excluding background).
     device : torch.device
-        Device to load the model on ('cuda' or 'cpu')
-        
+        Device to load the model on ('cuda' or 'cpu').
+    ckpt_path : str, optional
+        Path to a local .pth checkpoint, or the literal string 'scratch'
+        for random initialization.
+    hf_variant : str, optional
+        Variant name to download from the HuggingFace Hub
+        (see `anatomix.model.load_from_hf.ANATOMIX_VARIANTS`).
+    num_downs, ngf, output_nc, norm, interp, pooling
+        Architecture kwargs forwarded to `Unet` when loading from
+        `ckpt_path` or training from scratch. Ignored when `hf_variant`
+        is used (kwargs come from the variant registry).
+
     Returns
     -------
     new_model : torch.nn.Sequential
-        Configured model with pretrained weights (if specified) and output layer
+        Configured model with pretrained weights (if specified) and an
+        appended segmentation head sized to `n_classes`.
     """
-    # Initialize base U-Net model
-    model = Unet(3, 1, 16, 4, ngf=16).to(device)
-    
-    if pretrained_ckpt == 'scratch':
+    if (ckpt_path is None) == (hf_variant is None):
+        raise ValueError(
+            "Provide exactly one of `ckpt_path` or `hf_variant`."
+        )
+
+    if hf_variant is not None:
+        print(f"Transferring from HuggingFace variant '{hf_variant}'.")
+        model = load_from_hf(hf_variant).to(device)
+        feat_channels = ANATOMIX_VARIANTS[hf_variant]["unet_kwargs"]["output_nc"]
+    elif ckpt_path == "scratch":
         print("Training from random initialization.")
-        pass
+        model = Unet(
+            3, 1, output_nc, num_downs, ngf=ngf, norm=norm,
+            interp=interp, pooling=pooling,
+        ).to(device)
+        feat_channels = output_nc
     else:
-        print("Transferring from proposed pretrained network.")
-        model.load_state_dict(torch.load(pretrained_ckpt))
-        
+        if not os.path.isfile(ckpt_path):
+            raise FileNotFoundError(
+                f"Checkpoint file not found: {ckpt_path}"
+            )
+        print("Transferring from local checkpoint.")
+        model = Unet(
+            3, 1, output_nc, num_downs, ngf=ngf, norm=norm,
+            interp=interp, pooling=pooling,
+        ).to(device)
+        model = _load_handling_compile(
+            model, torch.load(ckpt_path, map_location="cpu"),
+        ).to(device)
+        feat_channels = output_nc
+
     # Add final classification layer
-    fin_layer = UnetOutBlock(3, 16, n_classes + 1, False).to(device)
-    new_model = torch.nn.Sequential(model, fin_layer)
-    new_model.to(device)
-    
+    fin_layer = UnetOutBlock(3, feat_channels, n_classes + 1, False).to(device)
+    new_model = torch.nn.Sequential(model, fin_layer).to(device)
     return new_model
 
 

--- a/anatomix/segmentation/train_segmentation.py
+++ b/anatomix/segmentation/train_segmentation.py
@@ -89,9 +89,16 @@ def main(opt):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     
     new_model = load_model(
-        opt.pretrained_ckpt,
         opt.n_classes,
         device,
+        ckpt_path=opt.pretrained_ckpt,
+        hf_variant=opt.hf_variant,
+        num_downs=opt.num_downs,
+        ngf=opt.ngf,
+        output_nc=opt.output_nc,
+        norm=opt.norm,
+        interp=opt.interp,
+        pooling=opt.pooling,
     )
     
     # Create Dice + CE loss function
@@ -291,12 +298,52 @@ if __name__ == "__main__":
         '--train_amount', type=int, default=3,
         help="No. of training samples to use for few-shot training",
     )
-    parser.add_argument(
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
         '--pretrained_ckpt',
         type=str,
-        default='../../model-weights/anatomix.pth',
-        help="Default points to model weights path. "
-        "Set to 'scratch' for random initialization",
+        default=None,
+        help="Path to a local .pth checkpoint, or 'scratch' for random "
+             "initialization.",
+    )
+    src.add_argument(
+        '--hf_variant',
+        type=str,
+        default=None,
+        help="HuggingFace Hub variant to download from neeldey/anatomix "
+             "(e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').",
+    )
+    # Unet architecture kwargs. Only used with --pretrained_ckpt (or 'scratch');
+    # ignored for --hf_variant (kwargs come from the variant registry).
+    parser.add_argument(
+        '--num_downs', type=int, default=4,
+        help="Number of downsampling layers in the U-Net. Default 4. "
+             "Only used with --pretrained_ckpt.",
+    )
+    parser.add_argument(
+        '--ngf', type=int, default=16,
+        help="Channel multiplier for the U-Net. Default 16. "
+             "Only used with --pretrained_ckpt.",
+    )
+    parser.add_argument(
+        '--output_nc', type=int, default=16,
+        help="Number of output feature channels of the U-Net. Default 16. "
+             "Only used with --pretrained_ckpt.",
+    )
+    parser.add_argument(
+        '--norm', type=str, default='batch',
+        help="Normalization type ('batch', 'instance', 'none'). "
+             "Default 'batch'. Only used with --pretrained_ckpt.",
+    )
+    parser.add_argument(
+        '--interp', type=str, default='nearest',
+        help="Decoder upsampling mode ('nearest' or 'trilinear'). "
+             "Default 'nearest'. Only used with --pretrained_ckpt.",
+    )
+    parser.add_argument(
+        '--pooling', type=str, default='Max',
+        help="Pooling type ('Max' or 'Avg'). Default 'Max'. "
+             "Only used with --pretrained_ckpt.",
     )
     parser.add_argument(
         '--exp_name',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ monai
 tensorboard
 tqdm
 natsort
+huggingface_hub


### PR DESCRIPTION
- Added `anatomix-dev`, which is an experimental model that is both larger (36M vs 6M before) and gets much better features.
- Added support for loading directly from Huggingface Hub instead of local pth files.
- Updated registration and segmentation scripts to not hardcode Unet kwargs to support flexible architectures.
- Added pointer to DropGen for people interested in segmentation with anatomix.