### PR TITLE
Add stability tricks

### DIFF
--- a/anatomix/model/network.py
+++ b/anatomix/model/network.py
@@ -124,7 +124,7 @@ class ConvBlock(nn.Module):
         return x
 
 
-def get_norm_layer(ndims, norm='batch'):
+def get_norm_layer(ndims, norm='batch', eps=1e-5):
     """
     Get the normalization layer based on the number of dimensions and type of
     normalization.
@@ -134,26 +134,32 @@ def get_norm_layer(ndims, norm='batch'):
     ndims : int
         The number of dimensions for the normalization layer (1--3).
     norm : str, optional
-        The type of normalization to use. 
+        The type of normalization to use.
         Options are 'batch', 'instance', 'instance_affine', or 'none'.
-        'instance_affine' is just instance norm with learned affine rescaling. 
+        'instance_affine' is just instance norm with learned affine rescaling.
         Default is 'batch'.
+    eps : float, optional
+        Numerical-stability epsilon baked into the norm layer. For instance
+        norm this floors the backward gain at ``1/sqrt(eps)``; raising it (e.g.
+        1e-2) caps the near-singular amplification on near-constant inputs.
+        Default 1e-5 (the PyTorch default).
 
     Returns
     -------
-    Norm : torch.nn.Module or None
-        The corresponding PyTorch normalization layer, or None if 'none'.
+    Norm : callable or None
+        A callable ``Norm(num_features)`` building the PyTorch normalization
+        layer (with ``eps`` bound), or None if 'none'.
     """
 
     if norm == 'batch':
-        return getattr(nn, f'BatchNorm{ndims}d')
+        return partial(getattr(nn, f'BatchNorm{ndims}d'), eps=eps)
 
     elif norm == 'instance':
-        return getattr(nn, f'InstanceNorm{ndims}d')
+        return partial(getattr(nn, f'InstanceNorm{ndims}d'), eps=eps)
 
     elif norm == 'instance_affine':
         Norm = getattr(nn, f'InstanceNorm{ndims}d')
-        return partial(Norm, affine=True)
+        return partial(Norm, affine=True, eps=eps)
 
     elif norm == 'none':
         return None
@@ -244,8 +250,12 @@ class Unet(nn.Module):
         Upsampling method for the decoder ('nearest' or 'trilinear'), 
         by default 'nearest'.
     use_skip_connection : bool, optional
-        Whether to use skip connections between corresponding encoder and 
+        Whether to use skip connections between corresponding encoder and
         decoder layers, by default True.
+    norm_eps : float, optional
+        Epsilon for the normalization layers (see ``get_norm_layer``). With
+        instance norm, larger values (e.g. 1e-2) cap the backward gain
+        ``1/sqrt(var+eps)`` on near-constant inputs. By default 1e-5.
 
     """
 
@@ -265,6 +275,7 @@ class Unet(nn.Module):
         pooling="Max",
         interp="nearest",
         use_skip_connection=True,
+        norm_eps=1e-5,
     ):
         """
         Initialize the U-Net model by constructing the architecture from the
@@ -286,7 +297,7 @@ class Unet(nn.Module):
         Pool = getattr(nn, '%sPool%dd' % (pooling,ndims))
 
         # Initialize normalization, activation, and final activation layers
-        Norm = get_norm_layer(ndims, norm)
+        Norm = get_norm_layer(ndims, norm, eps=norm_eps)
         Activation = get_actvn_layer(activation)
         FinalActivation = get_actvn_layer(final_act)
 

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -34,6 +34,7 @@ def define_G(
     pooling="Max",
     interp="nearest",
     num_downs=4,
+    norm_eps=1e-5,
 ):
     """
     Create a base network to pretrain.
@@ -98,6 +99,7 @@ def define_G(
             use_skip_connection=True,
             pooling=pooling,
             interp=interp,
+            norm_eps=norm_eps,
         )
     else:
         raise NotImplementedError(
@@ -121,6 +123,7 @@ def define_F(
     opt=None,
     activation="relu",
     use_mlp=True,
+    norm_eps=1e-5,
 ):
     """
     Create a patch sampling network (feature projector).
@@ -168,6 +171,7 @@ def define_F(
             n_mlps=n_mlps,
             activation=activation,
             norm=norm,
+            norm_eps=norm_eps,
         )
     else:
         raise NotImplementedError(
@@ -245,6 +249,7 @@ class PatchSampleF(nn.Module):
         n_mlps=2,
         activation="relu",
         norm="batch",
+        norm_eps=1e-5,
     ):
         # use the same patch_ids for multiple images in the batch
         super(PatchSampleF, self).__init__()
@@ -259,6 +264,7 @@ class PatchSampleF(nn.Module):
         self.n_mlps = n_mlps
         self.activation = activation
         self.normtype = norm
+        self.norm_eps = norm_eps
 
     def create_mlp(self, feats):
         """
@@ -271,7 +277,7 @@ class PatchSampleF(nn.Module):
         """
         for mlp_id, feat in enumerate(feats):
             input_nc = feat.shape[1]
-            norm = get_norm_layer(1, self.normtype)
+            norm = get_norm_layer(1, self.normtype, eps=self.norm_eps)
             Activation = get_actvn_layer(self.activation)
 
             if self.n_mlps == 2:

--- a/pretraining/models/supcl_model.py
+++ b/pretraining/models/supcl_model.py
@@ -351,6 +351,7 @@ class SupCLModel(BaseModel):
             pooling=opt.pool_type,
             interp=opt.interp_type,
             num_downs=opt.num_downs,
+            norm_eps=opt.norm_eps_G,
         )
 
         # Save base network configuration to file if not already present
@@ -374,6 +375,7 @@ class SupCLModel(BaseModel):
                     opt,
                     activation=opt.actF,
                     use_mlp=opt.use_mlp,
+                    norm_eps=opt.norm_eps_F,
                 )
 
                 if self.opt.use_mlp:
@@ -429,6 +431,10 @@ class SupCLModel(BaseModel):
             self.scaler = torch.cuda.amp.GradScaler(
                 enabled=(self.opt.gpu_ids is not None)
             )
+
+            # Most recent pre-clip grad norms, logged to tensorboard.
+            self.grad_norm_G = 0.0
+            self.grad_norm_F = 0.0
 
         else:
             # For inference, set feature names
@@ -519,19 +525,28 @@ class SupCLModel(BaseModel):
             self.scaler.scale(self.loss_G).backward()
 
         if (iters) % accum_iter == 0:
+            # Record netG's pre-clip grad norm; clip to max_norm_G only if requested
+            # (max_norm=inf just measures, leaving grads untouched). Unscale first so
+            # the norm is measured on true grads; scaler.step() would have unscaled
+            # anyway, so the measure-only path leaves training unchanged.
+            self.scaler.unscale_(self.optimizer_G)
+            self.grad_norm_G = nn.utils.clip_grad_norm_(
+                self.netG.parameters(),
+                max_norm=self.opt.max_norm_G if self.opt.clip_grad else float("inf"),
+                norm_type=2,
+            ).item()
             # step with scaler
             self.scaler.step(self.optimizer_G)
-            
+
             if self.opt.lambda_NCE > 0 and self.opt.use_mlp:
-                if self.opt.clip_grad:
-                    # unscale before clipping
-                    self.scaler.unscale_(self.optimizer_F)
-                    nn.utils.clip_grad_norm_(
-                        self.netF.parameters(),
-                        max_norm=self.opt.max_norm, 
-                        norm_type=2,
-                        error_if_nonfinite=True,
-                    )
+                # Always record netF's pre-clip grad norm; clip to max_norm_F only if
+                # requested (max_norm=inf just measures, leaving grads untouched).
+                self.scaler.unscale_(self.optimizer_F)
+                self.grad_norm_F = nn.utils.clip_grad_norm_(
+                    self.netF.parameters(),
+                    max_norm=self.opt.max_norm_F if self.opt.clip_grad else float("inf"),
+                    norm_type=2,
+                ).item()
                 self.scaler.step(self.optimizer_F)
             
             # update scaler

--- a/pretraining/options/base_options.py
+++ b/pretraining/options/base_options.py
@@ -117,6 +117,18 @@ class BaseOptions:
             help="instance/batch/no/layer norm for MLPs",
         )
         parser.add_argument(
+            "--norm_eps_G",
+            type=float,
+            default=1e-5,
+            help="epsilon in base-network (UNet) norm layers",
+        )
+        parser.add_argument(
+            "--norm_eps_F",
+            type=float,
+            default=1e-5,
+            help="epsilon in MLP (netF) norm layers",
+        )
+        parser.add_argument(
             "--actG",
             type=str,
             default="relu",

--- a/pretraining/options/train_options.py
+++ b/pretraining/options/train_options.py
@@ -141,7 +141,12 @@ class TrainOptions(BaseOptions):
             help="whether to clip gradient",
         )
         parser.add_argument(
-            "--max_norm", type=float, default=2, help="gradient clip norm max"
+            "--max_norm_G", type=float, default=2.0,
+            help="gradient clip norm max for base network (netG)",
+        )
+        parser.add_argument(
+            "--max_norm_F", type=float, default=2.0,
+            help="gradient clip norm max for MLP head (netF)",
         )
         parser.add_argument(
             "--grad_accum_iters",

--- a/pretraining/scripts/pretrain_anatomix.py
+++ b/pretraining/scripts/pretrain_anatomix.py
@@ -43,8 +43,13 @@ def main(args):
         "--netF_nc", str(args.netF_nc),
         "--normG", args.normG,
         "--normF", args.normF,
+        "--norm_eps_G", str(args.norm_eps_G),
+        "--norm_eps_F", str(args.norm_eps_F),
         "--netG", args.netG,
         "--grad_accum_iters", str(args.grad_accum_iters),
+        "--clip_grad", str(args.clip_grad),
+        "--max_norm_G", str(args.max_norm_G),
+        "--max_norm_F", str(args.max_norm_F),
         "--continue_train", str(args.continue_train),
         "--max_iters", str(args.max_iters),
         "--gpu_ids", str(args.gpu_ids),
@@ -280,6 +285,18 @@ if __name__ == "__main__":
         help="instance/batch/no/layer norm for MLP",
     )
     parser.add_argument(
+        "--norm_eps_G",
+        type=float,
+        default=1e-5,
+        help="epsilon in base-network (UNet) norm layers",
+    )
+    parser.add_argument(
+        "--norm_eps_F",
+        type=float,
+        default=1e-5,
+        help="epsilon in MLP (netF) norm layers",
+    )
+    parser.add_argument(
         "--netG",
         type=str,
         default="unet",
@@ -290,6 +307,24 @@ if __name__ == "__main__":
         type=int,
         default=1,
         help="Gradient accumulation iterations",
+    )
+    parser.add_argument(
+        "--clip_grad",
+        type=str,
+        default="False",
+        help="whether to clip gradients of netG and netF (True/False)",
+    )
+    parser.add_argument(
+        "--max_norm_G",
+        type=float,
+        default=2.0,
+        help="gradient clip norm max for base network (netG)",
+    )
+    parser.add_argument(
+        "--max_norm_F",
+        type=float,
+        default=2.0,
+        help="gradient clip norm max for MLP head (netF)",
     )
     parser.add_argument(
         "--continue_train",

--- a/pretraining/trainers/train.py
+++ b/pretraining/trainers/train.py
@@ -252,18 +252,6 @@ for epoch in range(
         # Visualization and Logging
         # -------------------------------
 
-        # Log pre-clip grad norms on every optimizer step (i.e. after each
-        # grad-accumulation window), decoupled from print_freq. This is exactly
-        # the gradient that gets clipped/applied; no staircase from accumulation.
-        if total_iters % opt.grad_accum_iters == 0:
-            model.visualizer.writer.add_scalar(
-                "grad_norm/G", model.grad_norm_G, total_iters
-            )
-            if hasattr(model, "netF"):
-                model.visualizer.writer.add_scalar(
-                    "grad_norm/F", model.grad_norm_F, total_iters
-                )
-
         # Display current results on tensorboard
         if total_iters % opt.display_freq == 0:
             model.visualizer.display_current_results(
@@ -283,6 +271,20 @@ for epoch in range(
                 model.optimizers[0].param_groups[0]["lr"],
                 total_iters,
             )
+
+        # Log pre-clip grad norms on every optimizer step (i.e. after each
+        # grad-accumulation window), decoupled from print_freq. This is exactly
+        # the gradient that gets clipped/applied; no staircase from accumulation.
+        # Tagged under "metrics/" so the panels sort *after* the "loss/" panels
+        # in TensorBoard (which orders tags alphabetically: loss < metrics).
+        if total_iters % opt.grad_accum_iters == 0:
+            model.visualizer.writer.add_scalar(
+                "metrics/grad_norm_G", model.grad_norm_G, total_iters
+            )
+            if hasattr(model, "netF"):
+                model.visualizer.writer.add_scalar(
+                    "metrics/grad_norm_F", model.grad_norm_F, total_iters
+                )
 
         if (
             total_iters % opt.save_latest_freq == 0

--- a/pretraining/trainers/train.py
+++ b/pretraining/trainers/train.py
@@ -252,6 +252,18 @@ for epoch in range(
         # Visualization and Logging
         # -------------------------------
 
+        # Log pre-clip grad norms on every optimizer step (i.e. after each
+        # grad-accumulation window), decoupled from print_freq. This is exactly
+        # the gradient that gets clipped/applied; no staircase from accumulation.
+        if total_iters % opt.grad_accum_iters == 0:
+            model.visualizer.writer.add_scalar(
+                "grad_norm/G", model.grad_norm_G, total_iters
+            )
+            if hasattr(model, "netF"):
+                model.visualizer.writer.add_scalar(
+                    "grad_norm/F", model.grad_norm_F, total_iters
+                )
+
         # Display current results on tensorboard
         if total_iters % opt.display_freq == 0:
             model.visualizer.display_current_results(


### PR DESCRIPTION
- Add option to modify normalization layer epsilons for both the base network and the MLPs. Done because InstanceNorm can lead to weird results on volumes with constant intensity.
- Add option to clip gradients for both the base network and the MLPs (previously was only the MLPs). Each network has its own separate clip.
- Track gradient norms in tensorboard as well (why am I still using tensorboard??)