### PR TITLE
Update and add new deps; Autohandle local cuda diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ conda create -n anatomix python=3.11
 conda activate anatomix
 git clone https://github.com/neel-dey/anatomix.git
 cd anatomix
-pip install -e .
+./install.sh   # auto-detects CUDA: cu126 default, cu130 for CUDA-13 drivers, cpu if no GPU
 ```
 
 Or install the dependencies manually:
 ```
 conda create -n anatomix python=3.11
 conda activate anatomix
-pip install numpy nibabel scipy scikit-image nilearn h5py matplotlib torch==2.8.0 tensorboard tqdm monai torchio SimpleITK natsort huggingface_hub
+# change the cuda wheel to `cu130` if you're on CUDA13 or `cpu` if you're doing cpu-only
+pip install numpy nibabel scipy scikit-image nilearn h5py matplotlib tensorboard tqdm monai torchio SimpleITK natsort huggingface_hub dynamic-network-architectures torch==2.13.0 torchvision==0.28.0 --extra-index-url https://download.pytorch.org/whl/cu126
 ```
 
 ## Folder organization

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Auto-detect CUDA and install this repo with a matching torch build.
+# The wheel index is chosen from the driver's max CUDA version; pip picks the
+# CPU arch (x86_64 / aarch64) automatically. For CUDA 11.x drivers, install
+# manually with --extra-index-url .../cu118 (see README).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cuda=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: [0-9]+' | grep -oE '[0-9]+$' || true)
+
+if [ -z "${cuda:-}" ]; then
+  idx=cpu                       # no NVIDIA GPU
+elif [ "$cuda" -ge 13 ]; then
+  idx=cu130                     # Blackwell / CUDA-13 drivers
+else
+  idx=cu126                     # CUDA 12.x drivers (default)
+fi
+
+echo ">> detected CUDA=${cuda:-none} -> installing torch build: $idx"
+pip install -e . --extra-index-url "https://download.pytorch.org/whl/$idx"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,11 @@ nilearn
 h5py
 matplotlib
 torchio
-torch==2.8.0
+torch==2.13.0
+torchvision==0.28.0
 monai
 tensorboard
 tqdm
 natsort
 huggingface_hub
+dynamic-network-architectures


### PR DESCRIPTION
- Bump torch to 2.13
- Add installer script that detects local CUDA version and installs the right torch(vision) version
- Add dynamic-network-architectures from PyPI as a dep for a future PR