### PR TITLE
Add a 3D ViT architecture option for pretraining

### DIFF
--- a/anatomix/model/__init__.py
+++ b/anatomix/model/__init__.py
@@ -4,9 +4,8 @@ __all__ = ["Unet", "Primus", "PrimusV2", "PRIMUS_CONFIGS"]
 
 
 def __getattr__(name):
-    # Lazy import so plain UNet use doesn't pull the 3D ViT's heavier deps
-    # (timm / dynamic_network_architectures); loaded only on demand.
     if name in ("Primus", "PrimusV2", "PRIMUS_CONFIGS"):
         from . import vit3d
+
         return getattr(vit3d, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/anatomix/model/__init__.py
+++ b/anatomix/model/__init__.py
@@ -1,3 +1,12 @@
 from .network import Unet
 
-__all__ = ["Unet"]
+__all__ = ["Unet", "Primus", "PrimusV2", "PRIMUS_CONFIGS"]
+
+
+def __getattr__(name):
+    # Lazy import so plain UNet use doesn't pull the 3D ViT's heavier deps
+    # (timm / dynamic_network_architectures); loaded only on demand.
+    if name in ("Primus", "PrimusV2", "PRIMUS_CONFIGS"):
+        from . import vit3d
+        return getattr(vit3d, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/anatomix/model/__init__.py
+++ b/anatomix/model/__init__.py
@@ -4,6 +4,7 @@ __all__ = ["Unet", "Primus", "PrimusV2", "PRIMUS_CONFIGS"]
 
 
 def __getattr__(name):
+    """Lazily import optional 3D ViT (Primus) symbols."""
     if name in ("Primus", "PrimusV2", "PRIMUS_CONFIGS"):
         from . import vit3d
 

--- a/anatomix/model/vit3d/__init__.py
+++ b/anatomix/model/vit3d/__init__.py
@@ -1,4 +1,4 @@
-"""Primus model extensions for Anatomix."""
+"""3D ViT (Primus) model backbones for anatomix."""
 from .architectures import PRIMUS_CONFIGS, Primus, PrimusV2
 
 __all__ = ["Primus", "PrimusV2", "PRIMUS_CONFIGS"]

--- a/anatomix/model/vit3d/__init__.py
+++ b/anatomix/model/vit3d/__init__.py
@@ -1,0 +1,5 @@
+"""Vendored 3D ViT (Primus / PrimusV2) classes + PRIMUS_CONFIGS; heavy blocks
+come from dynamic_network_architectures / timm. See architectures.py."""
+from .architectures import PRIMUS_CONFIGS, Primus, PrimusV2
+
+__all__ = ["Primus", "PrimusV2", "PRIMUS_CONFIGS"]

--- a/anatomix/model/vit3d/__init__.py
+++ b/anatomix/model/vit3d/__init__.py
@@ -1,4 +1,4 @@
-"""3D ViT (Primus) model backbones for anatomix."""
+"""3D ViT (Primus; https://arxiv.org/pdf/2503.01835) model backbones."""
 from .architectures import PRIMUS_CONFIGS, Primus, PrimusV2
 
 __all__ = ["Primus", "PrimusV2", "PRIMUS_CONFIGS"]

--- a/anatomix/model/vit3d/__init__.py
+++ b/anatomix/model/vit3d/__init__.py
@@ -1,6 +1,4 @@
-"""Local copy of the 3D ViT (Primus / PrimusV2) model definitions + PRIMUS_CONFIGS;
-heavy blocks come from dynamic_network_architectures / timm. See architectures.py
-for why these are copied and for the upstream citation."""
+"""Primus model extensions for Anatomix."""
 from .architectures import PRIMUS_CONFIGS, Primus, PrimusV2
 
 __all__ = ["Primus", "PrimusV2", "PRIMUS_CONFIGS"]

--- a/anatomix/model/vit3d/__init__.py
+++ b/anatomix/model/vit3d/__init__.py
@@ -1,5 +1,6 @@
-"""Vendored 3D ViT (Primus / PrimusV2) classes + PRIMUS_CONFIGS; heavy blocks
-come from dynamic_network_architectures / timm. See architectures.py."""
+"""Local copy of the 3D ViT (Primus / PrimusV2) model definitions + PRIMUS_CONFIGS;
+heavy blocks come from dynamic_network_architectures / timm. See architectures.py
+for why these are copied and for the upstream citation."""
 from .architectures import PRIMUS_CONFIGS, Primus, PrimusV2
 
 __all__ = ["Primus", "PrimusV2", "PRIMUS_CONFIGS"]

--- a/anatomix/model/vit3d/architectures.py
+++ b/anatomix/model/vit3d/architectures.py
@@ -1,12 +1,19 @@
 """
-Vendored Primus / PrimusV2 (v1 / v2) 3D ViT, adapted from
-``dynamic_network_architectures.architectures.primus`` to expose two tokenizer
-knobs as constructor args: ``num_register_tokens`` (ViT register tokens) and
-``in_eps`` (PrimusV2's deeper-tokenizer InstanceNorm3d eps, hardcoded to 1e-5
-upstream). Only the model-definition classes are vendored; heavy blocks (``Eva``,
-``PatchDecode``, RoPE, weight init) come from the installed
-``dynamic_network_architectures`` / ``timm``. The submodule tree matches upstream,
-so checkpoints are interchangeable with the official Primus / PrimusV2.
+Local copy of the Primus / PrimusV2 (v1 / v2) 3D ViT model definitions from
+MIC-DKFZ ``dynamic-network-architectures``
+(https://github.com/MIC-DKFZ/dynamic-network-architectures ->
+``dynamic_network_architectures.architectures.primus``).
+
+Why copied rather than imported: the upstream ``Primus`` / ``PrimusV2`` classes
+hardcode settings we need to sweep -- notably the register tokens
+(``num_register_tokens``) and the deeper-tokenizer InstanceNorm3d eps (``in_eps``,
+1e-5 upstream) -- plus a couple of stability options (QK-norm, output norm).
+Reproducing the (small) class definitions here exposes them as constructor args
+without forking the whole package. Only these definitions are copied; the heavy
+building blocks (``Eva``, ``PatchDecode``, RoPE, weight init) are still imported
+from the installed ``dynamic_network_architectures`` / ``timm``, so the submodule
+tree matches upstream and checkpoints stay interchangeable with the official
+Primus / PrimusV2.
 """
 from typing import Tuple
 
@@ -157,7 +164,7 @@ class Primus(AbstractDynamicNetworkArchitectures):
             scale_attn_inner=scale_attn_inner,
         )
 
-        # QK-norm: the vendored ``Eva`` builder doesn't expose timm's qk_norm, so enable
+        # QK-norm: the upstream ``Eva`` builder doesn't expose timm's qk_norm, so enable
         # it post-hoc by swapping per-head LayerNorm(head_dim) in. Bounds the pre-softmax
         # logits, preventing the attention-sink that injects a spatially-uniform (DC)
         # component -> the per-channel output bias that hijacks argmax. Adds

--- a/anatomix/model/vit3d/architectures.py
+++ b/anatomix/model/vit3d/architectures.py
@@ -1,0 +1,346 @@
+"""
+Vendored Primus / PrimusV2 (v1 / v2) 3D ViT, adapted from
+``dynamic_network_architectures.architectures.primus`` to expose two tokenizer
+knobs as constructor args: ``num_register_tokens`` (ViT register tokens) and
+``in_eps`` (PrimusV2's deeper-tokenizer InstanceNorm3d eps, hardcoded to 1e-5
+upstream). Only the model-definition classes are vendored; heavy blocks (``Eva``,
+``PatchDecode``, RoPE, weight init) come from the installed
+``dynamic_network_architectures`` / ``timm``. The submodule tree matches upstream,
+so checkpoints are interchangeable with the official Primus / PrimusV2.
+"""
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from timm.layers import RotaryEmbeddingCat
+from dynamic_network_architectures.architectures.abstract_arch import (
+    AbstractDynamicNetworkArchitectures,
+)
+from dynamic_network_architectures.building_blocks.eva import Eva
+from dynamic_network_architectures.building_blocks.patch_encode_decode import (
+    LayerNormNd,
+    PatchDecode,
+    PatchEmbed,
+)
+from dynamic_network_architectures.initialization.weight_init import InitWeights_He
+from einops import rearrange
+
+from .deep_tokenizer import PatchEmbedDeeper
+
+
+# Per-config depth / heads / embed_dim.
+PRIMUS_CONFIGS = {
+    "S": {"eva_depth": 12, "eva_numheads": 6, "embed_dim": 396},
+    "B": {"eva_depth": 12, "eva_numheads": 12, "embed_dim": 792},
+    "M": {"eva_depth": 16, "eva_numheads": 12, "embed_dim": 864},
+    "L": {"eva_depth": 24, "eva_numheads": 16, "embed_dim": 1056},
+}
+
+
+class ChannelDemean(nn.Module):
+    """Subtract each channel's per-sample spatial mean (param-free demean; no
+    variance rescale)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x - x.mean(dim=(2, 3, 4), keepdim=True)
+
+
+class ChannelLayerNorm(nn.Module):
+    """Affine-free LayerNorm across channels per voxel (zero-mean / unit-std).
+    Param-free; the forward argmax-over-channels is unchanged."""
+
+    def __init__(self, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mu = x.mean(dim=1, keepdim=True)
+        var = x.var(dim=1, unbiased=False, keepdim=True)
+        return (x - mu) / torch.sqrt(var + self.eps)
+
+
+def build_out_norm(mode, num_classes, eps):
+    """Resolve ``--primus_out_norm`` to a param-free output-norm module. Modes:
+    ``none`` -> Identity (default; matches the official state_dict);
+    ``instance`` -> affine-free InstanceNorm3d (per-channel demean + unit-variance over space);
+    ``demean`` -> per-channel demean only (ChannelDemean);
+    ``layernorm`` -> affine-free per-voxel LayerNorm across channels (ChannelLayerNorm);
+    ``layernorm_affine`` -> same, with a learned per-channel affine (``LayerNormNd``).
+    Bools accepted for back-compat (True -> instance, False -> none). Only
+    ``layernorm_affine`` adds params (``out_norm.{weight,bias}``); other modes leave the
+    state_dict unchanged, so existing checkpoints load.
+    """
+    if isinstance(mode, bool):
+        mode = "instance" if mode else "none"
+    mode = (mode or "none").lower()
+    if mode in ("none", "identity", "off"):
+        return nn.Identity()
+    if mode in ("instance", "instancenorm", "in"):
+        return nn.InstanceNorm3d(num_classes, eps=eps, affine=False)
+    if mode in ("demean", "center"):
+        return ChannelDemean()
+    if mode in ("layernorm", "layer", "ln"):
+        return ChannelLayerNorm(eps=eps)
+    if mode in ("layernorm_affine", "layernorm-affine", "ln_affine"):
+        return LayerNormNd(num_classes, eps=eps)
+    raise ValueError(
+        "out_norm must be one of 'none' | 'instance' | 'demean' | 'layernorm' | "
+        "'layernorm_affine' (or a bool); got %r" % (mode,)
+    )
+
+
+class Primus(AbstractDynamicNetworkArchitectures):
+    """Primus v1: single-conv ``PatchEmbed`` tokenizer + EVA ViT + PatchDecode."""
+
+    def __init__(
+        self,
+        input_channels: int,
+        embed_dim: int,
+        patch_embed_size: Tuple[int, ...],
+        num_classes: int,
+        eva_depth: int = 24,
+        eva_numheads: int = 16,
+        input_shape: Tuple[int, ...] = None,
+        decoder_norm=LayerNormNd,
+        decoder_act=nn.GELU,
+        num_register_tokens: int = 0,
+        use_rot_pos_emb: bool = True,
+        use_abs_pos_embed: bool = True,
+        mlp_ratio=4 * 2 / 3,
+        drop_path_rate=0,
+        patch_drop_rate: float = 0.0,
+        proj_drop_rate: float = 0.0,
+        attn_drop_rate: float = 0.0,
+        rope_impl=RotaryEmbeddingCat,
+        rope_kwargs=None,
+        init_values=None,
+        scale_attn_inner=False,
+        qk_norm=False,
+        out_norm="none",
+        out_norm_eps=1e-5,
+        register_init_std=1e-6,
+    ):
+        assert input_shape is not None
+        assert len(input_shape) == 3, "Currently only 3d is supported"
+        assert all([j % i == 0 for i, j in zip(patch_embed_size, input_shape)])
+
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.key_to_encoder = "eva"
+        self.key_to_stem = "down_projection"
+        self.keys_to_in_proj = ("down_projection.proj",)
+        self.key_to_lpe = "eva.pos_embed"
+
+        self.down_projection = PatchEmbed(patch_embed_size, input_channels, embed_dim)
+        self.up_projection = PatchDecode(
+            patch_embed_size, embed_dim, num_classes, norm=decoder_norm, activation=decoder_act
+        )
+
+        # we need to compute the ref_feat_shape for eva
+        self.eva = Eva(
+            embed_dim=embed_dim,
+            depth=eva_depth,
+            num_heads=eva_numheads,
+            ref_feat_shape=tuple([i // ds for i, ds in zip(input_shape, patch_embed_size)]),
+            num_reg_tokens=num_register_tokens,
+            use_rot_pos_emb=use_rot_pos_emb,
+            use_abs_pos_emb=use_abs_pos_embed,
+            mlp_ratio=mlp_ratio,
+            drop_path_rate=drop_path_rate,
+            patch_drop_rate=patch_drop_rate,
+            proj_drop_rate=proj_drop_rate,
+            attn_drop_rate=attn_drop_rate,
+            rope_impl=rope_impl,
+            rope_kwargs=rope_kwargs,
+            init_values=init_values,
+            scale_attn_inner=scale_attn_inner,
+        )
+
+        # QK-norm: the vendored ``Eva`` builder doesn't expose timm's qk_norm, so enable
+        # it post-hoc by swapping per-head LayerNorm(head_dim) in. Bounds the pre-softmax
+        # logits, preventing the attention-sink that injects a spatially-uniform (DC)
+        # component -> the per-channel output bias that hijacks argmax. Adds
+        # eva.blocks.*.attn.{q,k}_norm.{weight,bias} to the state_dict.
+        if qk_norm:
+            for blk in self.eva.blocks:
+                attn = blk.attn
+                head_dim = getattr(attn, "head_dim", None) or (
+                    attn.q_proj.out_features // attn.num_heads
+                )
+                attn.q_norm = nn.LayerNorm(head_dim)
+                attn.k_norm = nn.LayerNorm(head_dim)
+
+        # Optional param-free spatial norm on the dense output (see build_out_norm);
+        # counters the per-channel DC/scale offset the ViT's channel-wise LayerNorm
+        # leaves unchecked. eps reuses ``--primus_v2_in_eps``.
+        self.out_norm = build_out_norm(out_norm, num_classes, out_norm_eps)
+
+        self.mask_token: torch.Tensor
+        self.register_buffer("mask_token", torch.zeros(1, 1, embed_dim))
+
+        if num_register_tokens > 0:
+            self.register_tokens = (
+                nn.Parameter(torch.zeros(1, num_register_tokens, embed_dim)) if num_register_tokens else None
+            )
+            # Upstream std 1e-6 leaves registers inert (never attended); a token-scale
+            # init (~0.02, like pos_embed) makes them recruitable as the attention sink.
+            nn.init.normal_(self.register_tokens, std=register_init_std)
+        else:
+            self.register_tokens = None
+
+        self.down_projection.apply(InitWeights_He(1e-2))
+        self.up_projection.apply(InitWeights_He(1e-2))
+        # eva has its own initialization
+
+    def restore_full_sequence(self, x, keep_indices, num_patches):
+        """
+        Restore the full sequence by filling blanks with mask tokens and reordering.
+        """
+        if keep_indices is None:
+            return x, None
+        B, num_kept, C = x.shape
+        device = x.device
+
+        # Create mask tokens for missing patches
+        num_masked = num_patches - num_kept
+        mask_tokens = self.mask_token.repeat(B, num_masked, 1)
+
+        # Prepare an empty tensor for the restored sequence
+        restored = torch.zeros(B, num_patches, C, device=device)
+        restored_mask = torch.zeros(B, num_patches, dtype=torch.bool, device=device)
+
+        # Assign the kept patches and mask tokens in the correct positions
+        for i in range(B):
+            kept_pos = keep_indices[i]
+            all_indices = torch.arange(num_patches, device=device)  # Create tensor of all indices
+            mask = torch.ones(num_patches, device=device, dtype=torch.bool)  # Start with all True
+            mask[kept_pos] = False  # Set kept positions to False
+            masked_pos = all_indices[mask]  # Extract indices not in kept_pos
+
+            restored[i, kept_pos] = x[i]
+            restored[i, masked_pos] = mask_tokens[i, : len(masked_pos)]
+            restored_mask[i, kept_pos] = True
+
+        return (restored, restored_mask)
+
+    def forward(self, x, ret_mask=False):
+        FW, FH, FD = x.shape[2:]  # Full W , ...
+        x = self.down_projection(x)
+        # last output of the encoder is the input to EVA
+        B, C, W, H, D = x.shape
+        num_patches = W * H * D
+
+        x = rearrange(x, "b c w h d -> b (w h d) c")
+        if self.register_tokens is not None:
+            x = torch.cat(
+                (
+                    self.register_tokens.expand(x.shape[0], -1, -1),
+                    x,
+                ),
+                dim=1,
+            )
+        x, keep_indices = self.eva(x)
+
+        if self.register_tokens is not None:
+            x = x[:, self.register_tokens.shape[1] :]  # Removes the register tokens
+        # In-fill in-active patches with empty tokens
+        restored_x, restoration_mask = self.restore_full_sequence(x, keep_indices, num_patches)
+        x = rearrange(restored_x, "b (w h d) c -> b c w h d", h=H, w=W, d=D)
+        if restoration_mask is not None:
+            mask = rearrange(restoration_mask, "b (w h d) -> b w h d", h=H, w=W, d=D)
+            full_mask = (
+                mask.repeat_interleave(FW // W, dim=1)
+                .repeat_interleave(FH // H, dim=2)
+                .repeat_interleave(FD // D, dim=3)
+            )
+            full_mask = full_mask[:, None, ...]  # Add channel dimension  # [B, 1, W, H, D]
+        else:
+            full_mask = None
+
+        dec_out = self.out_norm(self.up_projection(x))
+        if ret_mask:
+            return dec_out, full_mask
+        else:
+            return dec_out
+
+    def compute_conv_feature_map_size(self, input_size):
+        raise NotImplementedError("yuck")
+
+
+class PrimusV2(Primus):
+    """Primus v2: same as v1 but with the deeper residual tokenizer
+    (``PatchEmbedDeeper``), whose InstanceNorm3d eps is configurable via
+    ``in_eps``. The deeper tokenizer is hardwired to an 8x stride."""
+
+    def __init__(
+        self,
+        input_channels: int,
+        embed_dim: int,
+        patch_embed_size: Tuple[int, ...],
+        num_classes: int,
+        eva_depth: int = 24,
+        eva_numheads: int = 16,
+        input_shape: Tuple[int, ...] = None,
+        decoder_norm=LayerNormNd,
+        decoder_act=nn.GELU,
+        num_register_tokens: int = 0,
+        use_rot_pos_emb: bool = True,
+        use_abs_pos_embed: bool = True,
+        mlp_ratio=4 * 2 / 3,
+        drop_path_rate=0,
+        patch_drop_rate: float = 0.0,
+        proj_drop_rate: float = 0.0,
+        attn_drop_rate: float = 0.0,
+        rope_impl=RotaryEmbeddingCat,
+        rope_kwargs=None,
+        init_values=None,
+        scale_attn_inner=False,
+        qk_norm=False,
+        out_norm="none",
+        out_norm_eps=1e-5,
+        register_init_std=1e-6,
+        in_eps: float = 1e-5,
+    ):
+        super().__init__(
+            input_channels=input_channels,
+            embed_dim=embed_dim,
+            patch_embed_size=patch_embed_size,
+            num_classes=num_classes,
+            eva_depth=eva_depth,
+            eva_numheads=eva_numheads,
+            input_shape=input_shape,
+            decoder_norm=decoder_norm,
+            decoder_act=decoder_act,
+            num_register_tokens=num_register_tokens,
+            use_rot_pos_emb=use_rot_pos_emb,
+            use_abs_pos_embed=use_abs_pos_embed,
+            mlp_ratio=mlp_ratio,
+            drop_path_rate=drop_path_rate,
+            patch_drop_rate=patch_drop_rate,
+            proj_drop_rate=proj_drop_rate,
+            attn_drop_rate=attn_drop_rate,
+            rope_impl=rope_impl,
+            rope_kwargs=rope_kwargs,
+            init_values=init_values,
+            scale_attn_inner=scale_attn_inner,
+            qk_norm=qk_norm,
+            out_norm=out_norm,
+            out_norm_eps=out_norm_eps,
+            register_init_std=register_init_std,
+        )
+        self.keys_to_in_proj = (
+            "down_projection.stem.blocks.0.conv1.conv",
+            "down_projection.stem.blocks.0.conv1.all_modules.0",
+        )
+        self.down_projection = PatchEmbedDeeper(
+            input_channels=input_channels,
+            embed_dim=embed_dim,
+            base_features=32,
+            depth_per_level=(1, 1, 1),
+            embed_proj_3x3x3=False,
+            embed_block_style="residual",
+            embed_block_type="basic",  # "basic" or "bottleneck" (if "residual" style)
+            in_eps=in_eps,
+        )
+        self.down_projection.apply(InitWeights_He(1e-2))

--- a/anatomix/model/vit3d/architectures.py
+++ b/anatomix/model/vit3d/architectures.py
@@ -1,6 +1,7 @@
 """This file imports 3D ViT backbones and exposes some configurables that were
 hardcoded in the upstream but might be modified in anatomix pretraining, such
-as normalization and register (ViT) initializations. The base models come from
+as output layer normalization and register (ViT) initializations. This also  
+adds QK normalization to the upstream. The base models come from 
 ``dynamic-network-architectures`` on PyPI.
 """
 
@@ -33,14 +34,19 @@ class ChannelDemean(nn.Module):
 
 
 class ChannelLayerNorm(nn.Module):
-    """Apply layer normalization with no learnable affines across channels."""
+    """Pointwise standardize channels independently, without affine renorms.
+
+    Parameters
+    ----------
+    eps : float, optional
+        eps added to the channel variance to prevent explosions.
+    """
 
     def __init__(self, eps: float = 1e-5):
         super().__init__()
         self.eps = eps
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Pointwise standardize a ``(B, C, D, H, W)`` tensor over channels"""
         mean = x.mean(dim=1, keepdim=True)
         var = x.var(dim=1, unbiased=False, keepdim=True)
         return (x - mean) / torch.sqrt(var + self.eps)
@@ -52,7 +58,8 @@ def build_out_norm(mode, num_classes, eps):
     Parameters
     ----------
     mode : str or bool
-        Normalization name; booleans select instance norm or identity.
+        ``none``, ``instance``, ``demean``, ``layernorm``, or
+        ``layernorm_affine``. Booleans map to instance norm or identity.
     num_classes : int
         Number of output channels.
     eps : float
@@ -80,12 +87,24 @@ def build_out_norm(mode, num_classes, eps):
 
 
 class _PrimusExtensions:
-    """Add anatomix normalization options to upstream Primus models."""
+    """Add normalization options to upstream models."""
 
     def _configure_extensions(
         self, qk_norm, out_norm, out_norm_eps, register_init_std
     ):
-        """Configure QK/output normalization and register initialization."""
+        """Configure the local extensions after the upstream model is built.
+
+        Parameters
+        ----------
+        qk_norm : bool
+            Add per-head LayerNorm to queries and keys in every EVA block.
+        out_norm : str or bool
+            Normalization applied to the decoded feature volume.
+        out_norm_eps : float
+            Epsilon used by the output normalization.
+        register_init_std : float
+            Standard deviation for initialized register tokens.
+        """
         if qk_norm:
             for block in self.eva.blocks:
                 attention = block.attn
@@ -107,22 +126,29 @@ class _PrimusExtensions:
     def forward(
         self, x, layers=None, encode_only=False, verbose=False, ret_mask=False
     ):
-        """Run Primus and adapt its output for anatomix pretraining.
+        """Run a 3D ViT and adapt its output for anatomix pretraining.
 
         Parameters
         ----------
         x : torch.Tensor of shape (B, C, D, H, W)
             Input volume.
         layers : sequence or bool, optional
-            A nonempty sequence requests the output as a feature; a boolean
-            preserves Primus' positional ``ret_mask`` API.
-        encode_only, verbose, ret_mask : bool, optional
-            Select feature/output-mask modes; ``verbose`` is compatibility-only.
+            A nonempty sequence requests the final volume as the sole NCE
+            feature. A boolean is treated as the upstream positional
+            ``ret_mask`` argument.
+        encode_only : bool, optional
+            With ``layers``, return only the feature list instead of both the
+            decoded volume and feature list.
+        verbose : bool, optional
+            Accepted for compatibility with the UNet pretraining interface.
+        ret_mask : bool, optional
+            Also return the spatial mask produced when patch dropout is active.
 
         Returns
         -------
-        torch.Tensor, list, or tuple
-            Normalized output, requested features, or output-mask pair.
+        torch.Tensor, list[torch.Tensor], or tuple
+            A ``(B, C_out, D, H, W)`` volume, requested feature result, or
+            ``(volume, mask)`` when ``ret_mask`` is true.
         """
         # Preserve Primus' positional ``ret_mask`` argument.
         if isinstance(layers, bool):
@@ -140,10 +166,51 @@ class _PrimusExtensions:
 
 
 class Primus(_PrimusExtensions, _Primus):
-    """Primus with optional QK and output normalization.
+    """Encode 3D patches with an EVA ViT and decode them to a dense volume.
 
-    ``qk_norm`` adds QK LayerNorm; ``out_norm`` and ``out_norm_eps`` configure output.
-    ``register_init_std`` controls register initialization; other inputs go upstream.
+    This wrapper adds query/key and output normalization controls to upstream
+    Primus while preserving its input and output shapes.
+
+    Parameters
+    ----------
+    input_channels, num_classes : int
+        Numbers of channels in the input and decoded output volumes.
+    embed_dim : int
+        Width of each patch token and transformer block.
+    patch_embed_size : tuple[int, int, int]
+        Non-overlapping patch size; each axis must divide ``input_shape``.
+    eva_depth, eva_numheads : int, optional
+        Number of transformer blocks and attention heads. ``embed_dim`` must
+        be divisible by ``eva_numheads``.
+    input_shape : tuple[int, int, int]
+        Spatial training crop shape used to size positional embeddings.
+    decoder_norm, decoder_act : type, optional
+        Normalization and activation classes used by the patch decoder.
+    num_register_tokens : int, optional
+        Extra learned tokens prepended during attention and removed before
+        decoding; zero disables them.
+    use_rot_pos_emb, use_abs_pos_embed : bool, optional
+        Enable rotary and learned absolute positional embeddings.
+    mlp_ratio : float, optional
+        Hidden width of each transformer MLP relative to ``embed_dim``.
+    drop_path_rate : float, optional
+        Maximum stochastic-depth probability across transformer blocks.
+    patch_drop_rate, proj_drop_rate, attn_drop_rate : float, optional
+        Dropout probabilities for input patches, projections, and attention.
+    rope_impl, rope_kwargs : object, dict, optional
+        Rotary-position implementation and its constructor arguments.
+    init_values : float or None, optional
+        Initial LayerScale value; ``None`` disables LayerScale.
+    scale_attn_inner : bool, optional
+        Apply an additional normalization inside each attention block.
+    qk_norm : bool, optional
+        Add per-head LayerNorm to attention queries and keys.
+    out_norm : str or bool, optional
+        Decoded-volume normalization; see :func:`build_out_norm` for modes.
+    out_norm_eps : float, optional
+        Numerical-stability epsilon for ``out_norm``.
+    register_init_std : float, optional
+        Initialization standard deviation for register tokens.
     """
 
     def __init__(
@@ -162,10 +229,16 @@ class Primus(_PrimusExtensions, _Primus):
 
 
 class PrimusV2(_PrimusExtensions, _PrimusV2):
-    """PrimusV2 with the Primus extensions and configurable tokenizer epsilon.
+    """The 3D ViT Primus V2 uses a residual convolutional tokenizer before
+    the transformer blocks.
 
-    ``in_eps`` sets InstanceNorm epsilon in the deeper tokenizer; remaining
-    extension arguments match :class:`Primus` and other arguments are upstream.
+    Common parameters are documented by :class:`Primus`. The three stride-2
+    tokenizer stages require a patch size of ``(8, 8, 8)``.
+
+    Parameters
+    ----------
+    in_eps : float, optional
+        Numerical-stability epsilon for every tokenizer InstanceNorm layer.
     """
 
     def __init__(

--- a/anatomix/model/vit3d/architectures.py
+++ b/anatomix/model/vit3d/architectures.py
@@ -1,7 +1,7 @@
-"""Primus extensions used by Anatomix pretraining.
-
-The base models come from ``dynamic-network-architectures``. These subclasses
-only expose the normalization and register settings used by this project.
+"""This file imports 3D ViT backbones and exposes some configurables that were
+hardcoded in the upstream but might be modified in anatomix pretraining, such
+as normalization and register (ViT) initializations. The base models come from
+``dynamic-network-architectures`` on PyPI.
 """
 
 import torch
@@ -28,24 +28,41 @@ class ChannelDemean(nn.Module):
     """Subtract each channel's spatial mean."""
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Center a ``(B, C, D, H, W)`` tensor, preserving its shape."""
         return x - x.mean(dim=(2, 3, 4), keepdim=True)
 
 
 class ChannelLayerNorm(nn.Module):
-    """Apply affine-free layer normalization across channels."""
+    """Apply layer normalization with no learnable affines across channels."""
 
     def __init__(self, eps: float = 1e-5):
         super().__init__()
         self.eps = eps
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Pointwise standardize a ``(B, C, D, H, W)`` tensor over channels"""
         mean = x.mean(dim=1, keepdim=True)
         var = x.var(dim=1, unbiased=False, keepdim=True)
         return (x - mean) / torch.sqrt(var + self.eps)
 
 
 def build_out_norm(mode, num_classes, eps):
-    """Build the requested output normalization layer."""
+    """Build an output normalization layer.
+
+    Parameters
+    ----------
+    mode : str or bool
+        Normalization name; booleans select instance norm or identity.
+    num_classes : int
+        Number of output channels.
+    eps : float
+        Numerical-stability epsilon.
+
+    Returns
+    -------
+    nn.Module
+        The requested normalization layer.
+    """
     if isinstance(mode, bool):
         mode = "instance" if mode else "none"
     mode = (mode or "none").lower()
@@ -63,9 +80,12 @@ def build_out_norm(mode, num_classes, eps):
 
 
 class _PrimusExtensions:
+    """Add anatomix normalization options to upstream Primus models."""
+
     def _configure_extensions(
         self, qk_norm, out_norm, out_norm_eps, register_init_std
     ):
+        """Configure QK/output normalization and register initialization."""
         if qk_norm:
             for block in self.eva.blocks:
                 attention = block.attn
@@ -87,6 +107,23 @@ class _PrimusExtensions:
     def forward(
         self, x, layers=None, encode_only=False, verbose=False, ret_mask=False
     ):
+        """Run Primus and adapt its output for anatomix pretraining.
+
+        Parameters
+        ----------
+        x : torch.Tensor of shape (B, C, D, H, W)
+            Input volume.
+        layers : sequence or bool, optional
+            A nonempty sequence requests the output as a feature; a boolean
+            preserves Primus' positional ``ret_mask`` API.
+        encode_only, verbose, ret_mask : bool, optional
+            Select feature/output-mask modes; ``verbose`` is compatibility-only.
+
+        Returns
+        -------
+        torch.Tensor, list, or tuple
+            Normalized output, requested features, or output-mask pair.
+        """
         # Preserve Primus' positional ``ret_mask`` argument.
         if isinstance(layers, bool):
             ret_mask = layers
@@ -103,7 +140,11 @@ class _PrimusExtensions:
 
 
 class Primus(_PrimusExtensions, _Primus):
-    """Primus with optional QK and output normalization."""
+    """Primus with optional QK and output normalization.
+
+    ``qk_norm`` adds QK LayerNorm; ``out_norm`` and ``out_norm_eps`` configure output.
+    ``register_init_std`` controls register initialization; other inputs go upstream.
+    """
 
     def __init__(
         self,
@@ -121,7 +162,11 @@ class Primus(_PrimusExtensions, _Primus):
 
 
 class PrimusV2(_PrimusExtensions, _PrimusV2):
-    """PrimusV2 with configurable tokenizer epsilon and Primus extensions."""
+    """PrimusV2 with the Primus extensions and configurable tokenizer epsilon.
+
+    ``in_eps`` sets InstanceNorm epsilon in the deeper tokenizer; remaining
+    extension arguments match :class:`Primus` and other arguments are upstream.
+    """
 
     def __init__(
         self,

--- a/anatomix/model/vit3d/architectures.py
+++ b/anatomix/model/vit3d/architectures.py
@@ -1,42 +1,21 @@
-"""
-Local copy of the Primus / PrimusV2 (v1 / v2) 3D ViT model definitions from
-MIC-DKFZ ``dynamic-network-architectures``
-(https://github.com/MIC-DKFZ/dynamic-network-architectures ->
-``dynamic_network_architectures.architectures.primus``).
+"""Primus extensions used by Anatomix pretraining.
 
-Why copied rather than imported: the upstream ``Primus`` / ``PrimusV2`` classes
-hardcode settings we need to sweep -- notably the register tokens
-(``num_register_tokens``) and the deeper-tokenizer InstanceNorm3d eps (``in_eps``,
-1e-5 upstream) -- plus a couple of stability options (QK-norm, output norm).
-Reproducing the (small) class definitions here exposes them as constructor args
-without forking the whole package. Only these definitions are copied; the heavy
-building blocks (``Eva``, ``PatchDecode``, RoPE, weight init) are still imported
-from the installed ``dynamic_network_architectures`` / ``timm``, so the submodule
-tree matches upstream and checkpoints stay interchangeable with the official
-Primus / PrimusV2.
+The base models come from ``dynamic-network-architectures``. These subclasses
+only expose the normalization and register settings used by this project.
 """
-from typing import Tuple
 
 import torch
 from torch import nn
 
-from timm.layers import RotaryEmbeddingCat
-from dynamic_network_architectures.architectures.abstract_arch import (
-    AbstractDynamicNetworkArchitectures,
+from dynamic_network_architectures.architectures.primus import (
+    Primus as _Primus,
+    PrimusV2 as _PrimusV2,
 )
-from dynamic_network_architectures.building_blocks.eva import Eva
 from dynamic_network_architectures.building_blocks.patch_encode_decode import (
     LayerNormNd,
-    PatchDecode,
-    PatchEmbed,
 )
-from dynamic_network_architectures.initialization.weight_init import InitWeights_He
-from einops import rearrange
-
-from .deep_tokenizer import PatchEmbedDeeper
 
 
-# Per-config depth / heads / embed_dim.
 PRIMUS_CONFIGS = {
     "S": {"eva_depth": 12, "eva_numheads": 6, "embed_dim": 396},
     "B": {"eva_depth": 12, "eva_numheads": 12, "embed_dim": 792},
@@ -46,38 +25,27 @@ PRIMUS_CONFIGS = {
 
 
 class ChannelDemean(nn.Module):
-    """Subtract each channel's per-sample spatial mean (param-free demean; no
-    variance rescale)."""
+    """Subtract each channel's spatial mean."""
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x - x.mean(dim=(2, 3, 4), keepdim=True)
 
 
 class ChannelLayerNorm(nn.Module):
-    """Affine-free LayerNorm across channels per voxel (zero-mean / unit-std).
-    Param-free; the forward argmax-over-channels is unchanged."""
+    """Apply affine-free layer normalization across channels."""
 
     def __init__(self, eps: float = 1e-5):
         super().__init__()
         self.eps = eps
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        mu = x.mean(dim=1, keepdim=True)
+        mean = x.mean(dim=1, keepdim=True)
         var = x.var(dim=1, unbiased=False, keepdim=True)
-        return (x - mu) / torch.sqrt(var + self.eps)
+        return (x - mean) / torch.sqrt(var + self.eps)
 
 
 def build_out_norm(mode, num_classes, eps):
-    """Resolve ``--primus_out_norm`` to a param-free output-norm module. Modes:
-    ``none`` -> Identity (default; matches the official state_dict);
-    ``instance`` -> affine-free InstanceNorm3d (per-channel demean + unit-variance over space);
-    ``demean`` -> per-channel demean only (ChannelDemean);
-    ``layernorm`` -> affine-free per-voxel LayerNorm across channels (ChannelLayerNorm);
-    ``layernorm_affine`` -> same, with a learned per-channel affine (``LayerNormNd``).
-    Bools accepted for back-compat (True -> instance, False -> none). Only
-    ``layernorm_affine`` adds params (``out_norm.{weight,bias}``); other modes leave the
-    state_dict unchanged, so existing checkpoints load.
-    """
+    """Build the requested output normalization layer."""
     if isinstance(mode, bool):
         mode = "instance" if mode else "none"
     mode = (mode or "none").lower()
@@ -91,263 +59,84 @@ def build_out_norm(mode, num_classes, eps):
         return ChannelLayerNorm(eps=eps)
     if mode in ("layernorm_affine", "layernorm-affine", "ln_affine"):
         return LayerNormNd(num_classes, eps=eps)
-    raise ValueError(
-        "out_norm must be one of 'none' | 'instance' | 'demean' | 'layernorm' | "
-        "'layernorm_affine' (or a bool); got %r" % (mode,)
-    )
+    raise ValueError(f"unsupported output normalization: {mode!r}")
 
 
-class Primus(AbstractDynamicNetworkArchitectures):
-    """Primus v1: single-conv ``PatchEmbed`` tokenizer + EVA ViT + PatchDecode."""
-
-    def __init__(
-        self,
-        input_channels: int,
-        embed_dim: int,
-        patch_embed_size: Tuple[int, ...],
-        num_classes: int,
-        eva_depth: int = 24,
-        eva_numheads: int = 16,
-        input_shape: Tuple[int, ...] = None,
-        decoder_norm=LayerNormNd,
-        decoder_act=nn.GELU,
-        num_register_tokens: int = 0,
-        use_rot_pos_emb: bool = True,
-        use_abs_pos_embed: bool = True,
-        mlp_ratio=4 * 2 / 3,
-        drop_path_rate=0,
-        patch_drop_rate: float = 0.0,
-        proj_drop_rate: float = 0.0,
-        attn_drop_rate: float = 0.0,
-        rope_impl=RotaryEmbeddingCat,
-        rope_kwargs=None,
-        init_values=None,
-        scale_attn_inner=False,
-        qk_norm=False,
-        out_norm="none",
-        out_norm_eps=1e-5,
-        register_init_std=1e-6,
+class _PrimusExtensions:
+    def _configure_extensions(
+        self, qk_norm, out_norm, out_norm_eps, register_init_std
     ):
-        assert input_shape is not None
-        assert len(input_shape) == 3, "Currently only 3d is supported"
-        assert all([j % i == 0 for i, j in zip(patch_embed_size, input_shape)])
-
-        super().__init__()
-        self.embed_dim = embed_dim
-        self.key_to_encoder = "eva"
-        self.key_to_stem = "down_projection"
-        self.keys_to_in_proj = ("down_projection.proj",)
-        self.key_to_lpe = "eva.pos_embed"
-
-        self.down_projection = PatchEmbed(patch_embed_size, input_channels, embed_dim)
-        self.up_projection = PatchDecode(
-            patch_embed_size, embed_dim, num_classes, norm=decoder_norm, activation=decoder_act
-        )
-
-        # we need to compute the ref_feat_shape for eva
-        self.eva = Eva(
-            embed_dim=embed_dim,
-            depth=eva_depth,
-            num_heads=eva_numheads,
-            ref_feat_shape=tuple([i // ds for i, ds in zip(input_shape, patch_embed_size)]),
-            num_reg_tokens=num_register_tokens,
-            use_rot_pos_emb=use_rot_pos_emb,
-            use_abs_pos_emb=use_abs_pos_embed,
-            mlp_ratio=mlp_ratio,
-            drop_path_rate=drop_path_rate,
-            patch_drop_rate=patch_drop_rate,
-            proj_drop_rate=proj_drop_rate,
-            attn_drop_rate=attn_drop_rate,
-            rope_impl=rope_impl,
-            rope_kwargs=rope_kwargs,
-            init_values=init_values,
-            scale_attn_inner=scale_attn_inner,
-        )
-
-        # QK-norm: the upstream ``Eva`` builder doesn't expose timm's qk_norm, so enable
-        # it post-hoc by swapping per-head LayerNorm(head_dim) in. Bounds the pre-softmax
-        # logits, preventing the attention-sink that injects a spatially-uniform (DC)
-        # component -> the per-channel output bias that hijacks argmax. Adds
-        # eva.blocks.*.attn.{q,k}_norm.{weight,bias} to the state_dict.
         if qk_norm:
-            for blk in self.eva.blocks:
-                attn = blk.attn
-                head_dim = getattr(attn, "head_dim", None) or (
-                    attn.q_proj.out_features // attn.num_heads
+            for block in self.eva.blocks:
+                attention = block.attn
+                head_dim = getattr(attention, "head_dim", None) or (
+                    attention.q_proj.out_features // attention.num_heads
                 )
-                attn.q_norm = nn.LayerNorm(head_dim)
-                attn.k_norm = nn.LayerNorm(head_dim)
-
-        # Optional param-free spatial norm on the dense output (see build_out_norm);
-        # counters the per-channel DC/scale offset the ViT's channel-wise LayerNorm
-        # leaves unchecked. eps reuses ``--primus_v2_in_eps``.
-        self.out_norm = build_out_norm(out_norm, num_classes, out_norm_eps)
-
-        self.mask_token: torch.Tensor
-        self.register_buffer("mask_token", torch.zeros(1, 1, embed_dim))
-
-        if num_register_tokens > 0:
-            self.register_tokens = (
-                nn.Parameter(torch.zeros(1, num_register_tokens, embed_dim)) if num_register_tokens else None
-            )
-            # Upstream std 1e-6 leaves registers inert (never attended); a token-scale
-            # init (~0.02, like pos_embed) makes them recruitable as the attention sink.
-            nn.init.normal_(self.register_tokens, std=register_init_std)
-        else:
-            self.register_tokens = None
-
-        self.down_projection.apply(InitWeights_He(1e-2))
-        self.up_projection.apply(InitWeights_He(1e-2))
-        # eva has its own initialization
-
-    def restore_full_sequence(self, x, keep_indices, num_patches):
-        """
-        Restore the full sequence by filling blanks with mask tokens and reordering.
-        """
-        if keep_indices is None:
-            return x, None
-        B, num_kept, C = x.shape
-        device = x.device
-
-        # Create mask tokens for missing patches
-        num_masked = num_patches - num_kept
-        mask_tokens = self.mask_token.repeat(B, num_masked, 1)
-
-        # Prepare an empty tensor for the restored sequence
-        restored = torch.zeros(B, num_patches, C, device=device)
-        restored_mask = torch.zeros(B, num_patches, dtype=torch.bool, device=device)
-
-        # Assign the kept patches and mask tokens in the correct positions
-        for i in range(B):
-            kept_pos = keep_indices[i]
-            all_indices = torch.arange(num_patches, device=device)  # Create tensor of all indices
-            mask = torch.ones(num_patches, device=device, dtype=torch.bool)  # Start with all True
-            mask[kept_pos] = False  # Set kept positions to False
-            masked_pos = all_indices[mask]  # Extract indices not in kept_pos
-
-            restored[i, kept_pos] = x[i]
-            restored[i, masked_pos] = mask_tokens[i, : len(masked_pos)]
-            restored_mask[i, kept_pos] = True
-
-        return (restored, restored_mask)
-
-    def forward(self, x, ret_mask=False):
-        FW, FH, FD = x.shape[2:]  # Full W , ...
-        x = self.down_projection(x)
-        # last output of the encoder is the input to EVA
-        B, C, W, H, D = x.shape
-        num_patches = W * H * D
-
-        x = rearrange(x, "b c w h d -> b (w h d) c")
-        if self.register_tokens is not None:
-            x = torch.cat(
-                (
-                    self.register_tokens.expand(x.shape[0], -1, -1),
-                    x,
-                ),
-                dim=1,
-            )
-        x, keep_indices = self.eva(x)
+                attention.q_norm = nn.LayerNorm(head_dim)
+                attention.k_norm = nn.LayerNorm(head_dim)
 
         if self.register_tokens is not None:
-            x = x[:, self.register_tokens.shape[1] :]  # Removes the register tokens
-        # In-fill in-active patches with empty tokens
-        restored_x, restoration_mask = self.restore_full_sequence(x, keep_indices, num_patches)
-        x = rearrange(restored_x, "b (w h d) c -> b c w h d", h=H, w=W, d=D)
-        if restoration_mask is not None:
-            mask = rearrange(restoration_mask, "b (w h d) -> b w h d", h=H, w=W, d=D)
-            full_mask = (
-                mask.repeat_interleave(FW // W, dim=1)
-                .repeat_interleave(FH // H, dim=2)
-                .repeat_interleave(FD // D, dim=3)
-            )
-            full_mask = full_mask[:, None, ...]  # Add channel dimension  # [B, 1, W, H, D]
-        else:
-            full_mask = None
+            # Upstream initializes registers with std=1e-6.
+            with torch.no_grad():
+                self.register_tokens.mul_(register_init_std / 1e-6)
 
-        dec_out = self.out_norm(self.up_projection(x))
+        self.out_norm = build_out_norm(
+            out_norm, self.up_projection.decode[-1].out_channels, out_norm_eps
+        )
+
+    def forward(
+        self, x, layers=None, encode_only=False, verbose=False, ret_mask=False
+    ):
+        # Preserve Primus' positional ``ret_mask`` argument.
+        if isinstance(layers, bool):
+            ret_mask = layers
+            layers = None
+        result = super().forward(x, ret_mask=ret_mask)
         if ret_mask:
-            return dec_out, full_mask
-        else:
-            return dec_out
+            output, mask = result
+            return self.out_norm(output), mask
+        output = self.out_norm(result)
+        if layers:
+            features = [output]
+            return features if encode_only else (output, features)
+        return output
 
-    def compute_conv_feature_map_size(self, input_size):
-        raise NotImplementedError("yuck")
 
-
-class PrimusV2(Primus):
-    """Primus v2: same as v1 but with the deeper residual tokenizer
-    (``PatchEmbedDeeper``), whose InstanceNorm3d eps is configurable via
-    ``in_eps``. The deeper tokenizer is hardwired to an 8x stride."""
+class Primus(_PrimusExtensions, _Primus):
+    """Primus with optional QK and output normalization."""
 
     def __init__(
         self,
-        input_channels: int,
-        embed_dim: int,
-        patch_embed_size: Tuple[int, ...],
-        num_classes: int,
-        eva_depth: int = 24,
-        eva_numheads: int = 16,
-        input_shape: Tuple[int, ...] = None,
-        decoder_norm=LayerNormNd,
-        decoder_act=nn.GELU,
-        num_register_tokens: int = 0,
-        use_rot_pos_emb: bool = True,
-        use_abs_pos_embed: bool = True,
-        mlp_ratio=4 * 2 / 3,
-        drop_path_rate=0,
-        patch_drop_rate: float = 0.0,
-        proj_drop_rate: float = 0.0,
-        attn_drop_rate: float = 0.0,
-        rope_impl=RotaryEmbeddingCat,
-        rope_kwargs=None,
-        init_values=None,
-        scale_attn_inner=False,
+        *args,
         qk_norm=False,
         out_norm="none",
         out_norm_eps=1e-5,
         register_init_std=1e-6,
-        in_eps: float = 1e-5,
+        **kwargs,
     ):
-        super().__init__(
-            input_channels=input_channels,
-            embed_dim=embed_dim,
-            patch_embed_size=patch_embed_size,
-            num_classes=num_classes,
-            eva_depth=eva_depth,
-            eva_numheads=eva_numheads,
-            input_shape=input_shape,
-            decoder_norm=decoder_norm,
-            decoder_act=decoder_act,
-            num_register_tokens=num_register_tokens,
-            use_rot_pos_emb=use_rot_pos_emb,
-            use_abs_pos_embed=use_abs_pos_embed,
-            mlp_ratio=mlp_ratio,
-            drop_path_rate=drop_path_rate,
-            patch_drop_rate=patch_drop_rate,
-            proj_drop_rate=proj_drop_rate,
-            attn_drop_rate=attn_drop_rate,
-            rope_impl=rope_impl,
-            rope_kwargs=rope_kwargs,
-            init_values=init_values,
-            scale_attn_inner=scale_attn_inner,
-            qk_norm=qk_norm,
-            out_norm=out_norm,
-            out_norm_eps=out_norm_eps,
-            register_init_std=register_init_std,
+        super().__init__(*args, **kwargs)
+        self._configure_extensions(
+            qk_norm, out_norm, out_norm_eps, register_init_std
         )
-        self.keys_to_in_proj = (
-            "down_projection.stem.blocks.0.conv1.conv",
-            "down_projection.stem.blocks.0.conv1.all_modules.0",
+
+
+class PrimusV2(_PrimusExtensions, _PrimusV2):
+    """PrimusV2 with configurable tokenizer epsilon and Primus extensions."""
+
+    def __init__(
+        self,
+        *args,
+        qk_norm=False,
+        out_norm="none",
+        out_norm_eps=1e-5,
+        register_init_std=1e-6,
+        in_eps=1e-5,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        for module in self.down_projection.modules():
+            if isinstance(module, nn.InstanceNorm3d):
+                module.eps = in_eps
+        self._configure_extensions(
+            qk_norm, out_norm, out_norm_eps, register_init_std
         )
-        self.down_projection = PatchEmbedDeeper(
-            input_channels=input_channels,
-            embed_dim=embed_dim,
-            base_features=32,
-            depth_per_level=(1, 1, 1),
-            embed_proj_3x3x3=False,
-            embed_block_style="residual",
-            embed_block_type="basic",  # "basic" or "bottleneck" (if "residual" style)
-            in_eps=in_eps,
-        )
-        self.down_projection.apply(InitWeights_He(1e-2))

--- a/anatomix/model/vit3d/deep_tokenizer.py
+++ b/anatomix/model/vit3d/deep_tokenizer.py
@@ -1,7 +1,10 @@
 """
-Vendored ``PatchEmbed_deeper`` (PrimusV2's deeper residual tokenizer). The only
-change vs upstream is the configurable InstanceNorm3d eps (``in_eps``); the
-submodule tree matches upstream so state_dicts stay interchangeable.
+Local copy of ``PatchEmbed_deeper`` (PrimusV2's deeper residual tokenizer) from
+MIC-DKFZ ``dynamic-network-architectures`` (see architectures.py for the full
+citation). Copied rather than imported for a single reason: to make the
+InstanceNorm3d eps (``in_eps``) a constructor arg instead of the upstream
+hardcoded 1e-5. The submodule tree matches upstream so state_dicts stay
+interchangeable.
 """
 from typing import Literal
 

--- a/anatomix/model/vit3d/deep_tokenizer.py
+++ b/anatomix/model/vit3d/deep_tokenizer.py
@@ -1,159 +1,38 @@
-"""
-Local copy of ``PatchEmbed_deeper`` (PrimusV2's deeper residual tokenizer) from
-MIC-DKFZ ``dynamic-network-architectures`` (see architectures.py for the full
-citation). Copied rather than imported for a single reason: to make the
-InstanceNorm3d eps (``in_eps``) a constructor arg instead of the upstream
-hardcoded 1e-5. The submodule tree matches upstream so state_dicts stay
-interchangeable.
-"""
-from typing import Literal
+"""Compatibility wrapper for the configurable PrimusV2 tokenizer."""
 
-import torch
 from torch import nn
 
-from dynamic_network_architectures.building_blocks.residual import (
-    BasicBlockD,
-    BottleneckD,
-    StackedResidualBlocks,
-)
-from dynamic_network_architectures.building_blocks.simple_conv_blocks import (
-    StackedConvBlocks,
+from dynamic_network_architectures.building_blocks.patch_encode_decode import (
+    PatchEmbed_deeper,
+    block_style,
+    block_type,
 )
 
-block_type = Literal["basic", "bottleneck"]
-block_style = Literal["residual", "conv"]
 
-
-class PatchEmbedDeeper(nn.Module):
-    """ResNet-style patch embedding with progressive downsampling.
-
-    Identical to upstream ``PatchEmbed_deeper`` except that the InstanceNorm3d
-    epsilon (``in_eps``) is configurable instead of hardcoded to 1e-5.
-    """
-
+class PatchEmbedDeeper(PatchEmbed_deeper):
     def __init__(
         self,
-        input_channels: int = 3,
-        embed_dim: int = 864,
-        base_features: int = 32,
-        depth_per_level: tuple = (1, 1, 1),
-        embed_proj_3x3x3: bool = False,
-        embed_block_type: block_type = "basic",
-        embed_block_style: block_style = "residual",
-        in_eps: float = 1e-5,
-    ) -> None:
-        super().__init__()
-
-        norm_op = nn.InstanceNorm3d
-        block = BottleneckD if embed_block_type == "bottleneck" else BasicBlockD
-        nonlin = nn.LeakyReLU if embed_block_type == "bottleneck" else nn.ReLU
-        norm_op_kwargs = {"eps": in_eps, "affine": True}  # <-- in_eps is the only change vs upstream
-        nonlin_kwargs = {"inplace": True}
-
-        if embed_block_type == "bottleneck":
-            bottleneck_channels = base_features // 4
-        else:
-            bottleneck_channels = None
-
-        if embed_block_style == "residual":
-            self.stem = StackedResidualBlocks(
-                1,
-                nn.Conv3d,
-                input_channels,
-                base_features,
-                [3, 3, 3],
-                1,
-                True,
-                norm_op,
-                norm_op_kwargs,
-                None,
-                None,
-                nonlin,
-                nonlin_kwargs,
-                block=block,
-            )
-        elif embed_block_style == "conv":
-            self.stem = StackedConvBlocks(
-                1,
-                nn.Conv3d,
-                input_channels,
-                base_features,
-                [3, 3, 3],
-                1,
-                True,
-                norm_op,
-                norm_op_kwargs,
-                None,
-                None,
-                nonlin,
-                nonlin_kwargs,
-            )
-        else:
-            raise ValueError(
-                f"Unknown embed_block_style: {embed_block_style}. "
-                "Must be 'residual' or 'conv'."
-            )
-
-        levels_needed = len(depth_per_level)
-
-        # Build encoder stages
-        self.stages = nn.ModuleList()
-        input_channels = base_features
-
-        for i in range(levels_needed):
-            # First block in each stage handles downsampling and channel increase
-            stride = 2
-            output_channels = base_features * (2**i)
-            if embed_block_style == "residual":
-                if embed_block_type == "bottleneck":
-                    bottleneck_channels = output_channels // 4
-                else:
-                    bottleneck_channels = None
-                stage = StackedResidualBlocks(
-                    n_blocks=depth_per_level[i],
-                    conv_op=nn.Conv3d,
-                    input_channels=input_channels,
-                    output_channels=output_channels,
-                    kernel_size=3,
-                    initial_stride=stride,
-                    conv_bias=False,
-                    norm_op=norm_op,
-                    norm_op_kwargs=norm_op_kwargs,
-                    dropout_op=None,
-                    dropout_op_kwargs=None,
-                    nonlin=nonlin,
-                    nonlin_kwargs=nonlin_kwargs,
-                    block=block,
-                    bottleneck_channels=bottleneck_channels,
-                )
-            elif embed_block_style == "conv":
-                stage = StackedConvBlocks(
-                    num_convs=depth_per_level[i],
-                    conv_op=nn.Conv3d,
-                    input_channels=input_channels,
-                    output_channels=output_channels,
-                    kernel_size=3,
-                    initial_stride=stride,
-                    conv_bias=False,
-                    norm_op=norm_op,
-                    norm_op_kwargs=norm_op_kwargs,
-                    dropout_op=None,
-                    dropout_op_kwargs=None,
-                    nonlin=nonlin,
-                    nonlin_kwargs=nonlin_kwargs,
-                )
-            self.stages.append(stage)
-            input_channels = output_channels
-
-        final_proj_kernel = [3, 3, 3] if embed_proj_3x3x3 else [1, 1, 1]
-        final_pad = [1, 1, 1] if embed_proj_3x3x3 else [0, 0, 0]
-        self.final_proj = nn.Conv3d(
-            input_channels, embed_dim, kernel_size=final_proj_kernel, stride=[1, 1, 1], padding=final_pad
+        input_channels=3,
+        embed_dim=864,
+        base_features=32,
+        depth_per_level=(1, 1, 1),
+        embed_proj_3x3x3=False,
+        embed_block_type="basic",
+        embed_block_style="residual",
+        in_eps=1e-5,
+    ):
+        super().__init__(
+            input_channels,
+            embed_dim,
+            base_features,
+            depth_per_level,
+            embed_proj_3x3x3,
+            embed_block_type,
+            embed_block_style,
         )
+        for module in self.modules():
+            if isinstance(module, nn.InstanceNorm3d):
+                module.eps = in_eps
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.stem(x)
-        for stage in self.stages:
-            x = stage(x)
-        x = self.final_proj(x)
-        return x
+
+__all__ = ["PatchEmbedDeeper", "block_style", "block_type"]

--- a/anatomix/model/vit3d/deep_tokenizer.py
+++ b/anatomix/model/vit3d/deep_tokenizer.py
@@ -10,6 +10,12 @@ from dynamic_network_architectures.building_blocks.patch_encode_decode import (
 
 
 class PatchEmbedDeeper(PatchEmbed_deeper):
+    """PrimusV2 tokenizer with configurable InstanceNorm epsilon.
+
+    ``in_eps`` sets epsilon on every tokenizer InstanceNorm layer; all other
+    inputs and the output match the upstream ``PatchEmbed_deeper`` class.
+    """
+
     def __init__(
         self,
         input_channels=3,

--- a/anatomix/model/vit3d/deep_tokenizer.py
+++ b/anatomix/model/vit3d/deep_tokenizer.py
@@ -10,10 +10,35 @@ from dynamic_network_architectures.building_blocks.patch_encode_decode import (
 
 
 class PatchEmbedDeeper(PatchEmbed_deeper):
-    """PrimusV2 tokenizer with configurable InstanceNorm epsilon.
+    """Downsample a 3D volume into patch embeddings with convolutional stages.
 
-    ``in_eps`` sets epsilon on every tokenizer InstanceNorm layer; all other
-    inputs and the output match the upstream ``PatchEmbed_deeper`` class.
+    This upstream-compatible PrimusV2 tokenizer only adds configurable
+    InstanceNorm epsilon.
+
+    Parameters
+    ----------
+    input_channels : int, optional
+        Number of channels in the input volume.
+    embed_dim : int, optional
+        Number of channels in the output embedding grid.
+    base_features : int, optional
+        Channel count in the stem and first downsampling stage.
+    depth_per_level : tuple[int, ...], optional
+        Block counts in successive stride-2 stages; its length determines the
+        total downsampling factor, ``2 ** len(depth_per_level)``.
+    embed_proj_3x3x3 : bool, optional
+        Use a 3x3x3 rather than 1x1x1 final embedding projection.
+    embed_block_type : {"basic", "bottleneck"}, optional
+        Residual block type; used only with residual-style stages.
+    embed_block_style : {"residual", "conv"}, optional
+        Build each stage from residual or plain convolutional blocks.
+    in_eps : float, optional
+        Epsilon used by every InstanceNorm3d layer.
+
+    Notes
+    -----
+    The inherited forward maps ``(B, C_in, D, H, W)`` to
+    ``(B, embed_dim, D/s, H/s, W/s)``, where ``s`` is the downsampling factor.
     """
 
     def __init__(

--- a/anatomix/model/vit3d/deep_tokenizer.py
+++ b/anatomix/model/vit3d/deep_tokenizer.py
@@ -1,0 +1,156 @@
+"""
+Vendored ``PatchEmbed_deeper`` (PrimusV2's deeper residual tokenizer). The only
+change vs upstream is the configurable InstanceNorm3d eps (``in_eps``); the
+submodule tree matches upstream so state_dicts stay interchangeable.
+"""
+from typing import Literal
+
+import torch
+from torch import nn
+
+from dynamic_network_architectures.building_blocks.residual import (
+    BasicBlockD,
+    BottleneckD,
+    StackedResidualBlocks,
+)
+from dynamic_network_architectures.building_blocks.simple_conv_blocks import (
+    StackedConvBlocks,
+)
+
+block_type = Literal["basic", "bottleneck"]
+block_style = Literal["residual", "conv"]
+
+
+class PatchEmbedDeeper(nn.Module):
+    """ResNet-style patch embedding with progressive downsampling.
+
+    Identical to upstream ``PatchEmbed_deeper`` except that the InstanceNorm3d
+    epsilon (``in_eps``) is configurable instead of hardcoded to 1e-5.
+    """
+
+    def __init__(
+        self,
+        input_channels: int = 3,
+        embed_dim: int = 864,
+        base_features: int = 32,
+        depth_per_level: tuple = (1, 1, 1),
+        embed_proj_3x3x3: bool = False,
+        embed_block_type: block_type = "basic",
+        embed_block_style: block_style = "residual",
+        in_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+
+        norm_op = nn.InstanceNorm3d
+        block = BottleneckD if embed_block_type == "bottleneck" else BasicBlockD
+        nonlin = nn.LeakyReLU if embed_block_type == "bottleneck" else nn.ReLU
+        norm_op_kwargs = {"eps": in_eps, "affine": True}  # <-- in_eps is the only change vs upstream
+        nonlin_kwargs = {"inplace": True}
+
+        if embed_block_type == "bottleneck":
+            bottleneck_channels = base_features // 4
+        else:
+            bottleneck_channels = None
+
+        if embed_block_style == "residual":
+            self.stem = StackedResidualBlocks(
+                1,
+                nn.Conv3d,
+                input_channels,
+                base_features,
+                [3, 3, 3],
+                1,
+                True,
+                norm_op,
+                norm_op_kwargs,
+                None,
+                None,
+                nonlin,
+                nonlin_kwargs,
+                block=block,
+            )
+        elif embed_block_style == "conv":
+            self.stem = StackedConvBlocks(
+                1,
+                nn.Conv3d,
+                input_channels,
+                base_features,
+                [3, 3, 3],
+                1,
+                True,
+                norm_op,
+                norm_op_kwargs,
+                None,
+                None,
+                nonlin,
+                nonlin_kwargs,
+            )
+        else:
+            raise ValueError(
+                f"Unknown embed_block_style: {embed_block_style}. "
+                "Must be 'residual' or 'conv'."
+            )
+
+        levels_needed = len(depth_per_level)
+
+        # Build encoder stages
+        self.stages = nn.ModuleList()
+        input_channels = base_features
+
+        for i in range(levels_needed):
+            # First block in each stage handles downsampling and channel increase
+            stride = 2
+            output_channels = base_features * (2**i)
+            if embed_block_style == "residual":
+                if embed_block_type == "bottleneck":
+                    bottleneck_channels = output_channels // 4
+                else:
+                    bottleneck_channels = None
+                stage = StackedResidualBlocks(
+                    n_blocks=depth_per_level[i],
+                    conv_op=nn.Conv3d,
+                    input_channels=input_channels,
+                    output_channels=output_channels,
+                    kernel_size=3,
+                    initial_stride=stride,
+                    conv_bias=False,
+                    norm_op=norm_op,
+                    norm_op_kwargs=norm_op_kwargs,
+                    dropout_op=None,
+                    dropout_op_kwargs=None,
+                    nonlin=nonlin,
+                    nonlin_kwargs=nonlin_kwargs,
+                    block=block,
+                    bottleneck_channels=bottleneck_channels,
+                )
+            elif embed_block_style == "conv":
+                stage = StackedConvBlocks(
+                    num_convs=depth_per_level[i],
+                    conv_op=nn.Conv3d,
+                    input_channels=input_channels,
+                    output_channels=output_channels,
+                    kernel_size=3,
+                    initial_stride=stride,
+                    conv_bias=False,
+                    norm_op=norm_op,
+                    norm_op_kwargs=norm_op_kwargs,
+                    dropout_op=None,
+                    dropout_op_kwargs=None,
+                    nonlin=nonlin,
+                    nonlin_kwargs=nonlin_kwargs,
+                )
+            self.stages.append(stage)
+            input_channels = output_channels
+
+        final_proj_kernel = [3, 3, 3] if embed_proj_3x3x3 else [1, 1, 1]
+        final_pad = [1, 1, 1] if embed_proj_3x3x3 else [0, 0, 0]
+        self.final_proj = nn.Conv3d(
+            input_channels, embed_dim, kernel_size=final_proj_kernel, stride=[1, 1, 1], padding=final_pad
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        for stage in self.stages:
+            x = stage(x)
+        x = self.final_proj(x)
+        return x

--- a/pretraining/README.md
+++ b/pretraining/README.md
@@ -18,94 +18,11 @@ Using the default 120K generated contrastive pairs, this will run for 600K itera
 Full CLI:
 ```
 $ python pretrain_anatomix.py -h
-Pretrain anatomix with configurable arguments.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --ckpt_dir CKPT_DIR   models are saved here
-  --dataroot DATAROOT   path to images
-  --name NAME           name of the run you're launching
-  --n_epochs N_EPOCHS   number of epochs with the initial learning rate
-  --n_epochs_decay N_EPOCHS_DECAY
-                        number of epochs to start linearly decaying learning
-                        rate to zero
-  --crop_size CROP_SIZE
-                        crop size
-  --batch_size BATCH_SIZE
-                        input batch size in terms of number of contrastive
-                        paired volumes
-  --dataset_mode DATASET_MODE
-                        chooses datasets
-  --model MODEL         chooses which model to use. only `supcl` supported as
-                        of now
-  --nce_T NCE_T         NCE temperature
-  --ndims NDIMS         network dimension: 2|3. only 3 supported as of now.
-  --input_nc INPUT_NC   number of input image channels
-  --output_nc OUTPUT_NC
-                        number of network output feature channels
-  --ngf NGF             number of filters in the first conv layer
-  --netF NETF           specify the feature network type. we use a patch
-                        sampling MLP
-  --n_mlps N_MLPS       number of MLP layers in netF
-  --num_threads NUM_THREADS
-                        number of threads for loading data
-  --lr LR               initial learning rate for adam
-  --print_freq PRINT_FREQ
-                        frequency of showing training results on console
-  --display_ncols DISPLAY_NCOLS
-                        if positive, display all images in a single web panel
-                        with certain number of images per row.
-  --display_slice DISPLAY_SLICE
-                        the slice index to display if inputs are 3D volumes
-  --display_freq DISPLAY_FREQ
-                        frequency of showing training results on screen
-  --save_latest_freq SAVE_LATEST_FREQ
-                        frequency of saving the latest results
-  --save_freq SAVE_FREQ
-                        frequency of saving checkpoints at the end of
-                        iterationss
-  --evaluation_freq EVALUATION_FREQ
-                        evaluation freq
-  --load_mode LOAD_MODE
-                        load entries randomly (train) or in order (test time)
-  --num_patches NUM_PATCHES
-                        number of patches
-  --lr_policy LR_POLICY
-                        specify learning rate policy to use
-  --init_type INIT_TYPE
-                        network initialization strategy
-  --n_val_during_train N_VAL_DURING_TRAIN
-                        number of batches to sample during a validation step
-  --lambda_NCE LAMBDA_NCE
-                        weight for NCE loss
-  --netF_nc NETF_NC     number of neurons for netF, the patch sampling MLP
-  --normG NORMG         instance/batch/no/layer norm for base network
-  --netG NETG           specify base network architecture
-  --grad_accum_iters GRAD_ACCUM_ITERS
-                        Gradient accumulation iterations
-  --continue_train CONTINUE_TRAIN
-                        continue training: load the latest model (True/False)
-  --gpu_ids GPU_IDS     gpu ids: e.g. 0 0,1,2, 0,2. use -1 for CPU
-  --nce_layers NCE_LAYERS
-                        comma-separated list of layers for NCE loss
-  --nce_weights NCE_WEIGHTS
-                        comma-separated list of weights for NCE loss layers
-  --seed SEED           Seed for torch, np, and random packages
-  --apply_same_inten_augment APPLY_SAME_INTEN_AUGMENT
-                        Whether to perform the same intensity augmentation on
-                        view 1 & 2 (True/False)
-
 ```
-
-## TODOs:
-- [ ] Support masking the regions from where to sample patches
-- [ ] Support 2D training
-- [ ] Support multi-GPU training
-- [ ] Support auto mixed precision
 
 PRs are very welcome! There are some code snippets in the current repository that point out where to make these changes and I can help if someone gets started.
 
 ## Credits (and disclaimers)
-This portion of the codebase is fork of this NeurIPS'22 [paper](https://github.com/mengweiren/longitudinal-representation-learning/tree/main)'s codebase, which itself a heavily modified fork of the [CUT](https://github.com/taesungp/contrastive-unpaired-translation/tree/master) repo. 
+This portion of the codebase is fork of this NeurIPS'22 [paper](https://github.com/mengweiren/longitudinal-representation-learning/tree/main)'s codebase, which itself a heavily modified fork of the [CUT](https://github.com/taesungp/contrastive-unpaired-translation/tree/master) repo.
 
 As a result, this is more "research code" and fragile than the rest of the repository. Please open issues and/or pull requests if you spot any issues.

--- a/pretraining/models/base_model.py
+++ b/pretraining/models/base_model.py
@@ -265,21 +265,13 @@ class BaseModel(ABC):
                     torch.save(net.cpu().state_dict(), save_path)
 
     def _output_head_keys(self, net, keys):
-        """Keys of ``net``'s output projection -- the only params a shape-mismatched
-        warm-start may leave at fresh init (e.g. a different output_nc). Empty set
-        when the head can't be identified, so load_networks refuses rather than
-        silently reinitializing critical weights (e.g. positional embeddings).
-        """
+        """Return output-head keys that a partial warm start may reinitialize."""
         core = getattr(net, "_orig_mod", net)  # unwrap torch.compile
         core = getattr(core, "module", core)   # unwrap DataParallel
 
         if hasattr(core, "up_projection"):
-            # 3D ViT: the PatchDecode output head.
             head = "up_projection."
         else:
-            # UNet: all layers live in one nn.Sequential `model`; the output head
-            # is the highest-indexed direct child that owns parameters (the
-            # final conv).
             seq = getattr(core, "model", None)
             if not isinstance(seq, torch.nn.Sequential):
                 return set()
@@ -345,11 +337,7 @@ class BaseModel(ABC):
                 try:
                     net.load_state_dict(state_dict)
                 except RuntimeError as e:
-                    # Strict load failed. Tolerate ONLY a differently shaped output
-                    # head (e.g. warm-starting across a different output_nc); leave
-                    # those at fresh init. Any other mismatch -- e.g. a pos-embed /
-                    # register-token change (--primus_num_register_tokens reshapes
-                    # eva.pos_embed) -- must NOT be silently reinitialized, so re-raise.
+                    # A partial warm start may differ only in its output head.
                     model_dict = net.state_dict()
                     ckpt_keys, model_keys = set(state_dict), set(model_dict)
 
@@ -358,8 +346,8 @@ class BaseModel(ABC):
                         for k in (ckpt_keys & model_keys)
                         if state_dict[k].size() != model_dict[k].size()
                     )
-                    missing = sorted(model_keys - ckpt_keys)  # in model, not ckpt
-                    unexpected = sorted(ckpt_keys - model_keys)  # in ckpt, not model
+                    missing = sorted(model_keys - ckpt_keys)
+                    unexpected = sorted(ckpt_keys - model_keys)
 
                     allowed = self._output_head_keys(net, model_keys)
                     offenders = sorted(
@@ -376,8 +364,6 @@ class BaseModel(ABC):
                             f"unexpected_in_ckpt={unexpected})"
                         ) from e
 
-                    # Only output-head params differ: copy every shape-matching
-                    # tensor and leave the output head at its fresh init.
                     for k in ckpt_keys & model_keys:
                         if state_dict[k].size() == model_dict[k].size():
                             model_dict[k] = state_dict[k]
@@ -503,4 +489,3 @@ class BaseModel(ABC):
             if net is not None:
                 for param in net.parameters():
                     param.requires_grad = requires_grad
-

--- a/pretraining/models/base_model.py
+++ b/pretraining/models/base_model.py
@@ -264,6 +264,39 @@ class BaseModel(ABC):
                 else:
                     torch.save(net.cpu().state_dict(), save_path)
 
+    def _output_head_keys(self, net, keys):
+        """Keys of ``net``'s output projection -- the only params a shape-mismatched
+        warm-start may leave at fresh init (e.g. a different output_nc). Empty set
+        when the head can't be identified, so load_networks refuses rather than
+        silently reinitializing critical weights (e.g. positional embeddings).
+        """
+        core = getattr(net, "_orig_mod", net)  # unwrap torch.compile
+        core = getattr(core, "module", core)   # unwrap DataParallel
+
+        if hasattr(core, "up_projection"):
+            # 3D ViT: the PatchDecode output head.
+            head = "up_projection."
+        else:
+            # UNet: all layers live in one nn.Sequential `model`; the output head
+            # is the highest-indexed direct child that owns parameters (the
+            # final conv).
+            seq = getattr(core, "model", None)
+            if not isinstance(seq, torch.nn.Sequential):
+                return set()
+            idxs = [
+                int(name)
+                for name, child in seq.named_children()
+                if any(True for _ in child.parameters(recurse=True))
+            ]
+            if not idxs:
+                return set()
+            head = f"model.{max(idxs)}."
+
+        def _strip(k):
+            return k.replace("module.", "").replace("_orig_mod.", "")
+
+        return {k for k in keys if _strip(k).startswith(head)}
+
     def load_networks(self, epoch, from_pretrained=False):
         """Load all the networks from the disk.
 
@@ -311,25 +344,49 @@ class BaseModel(ABC):
 
                 try:
                     net.load_state_dict(state_dict)
-                except:
+                except RuntimeError as e:
+                    # Strict load failed. Tolerate ONLY a differently shaped output
+                    # head (e.g. warm-starting across a different output_nc); leave
+                    # those at fresh init. Any other mismatch -- e.g. a pos-embed /
+                    # register-token change (--primus_num_register_tokens reshapes
+                    # eva.pos_embed) -- must NOT be silently reinitialized, so re-raise.
                     model_dict = net.state_dict()
-                    not_initialized = []
-                    for k, v in state_dict.items():
-                        if v.size() == model_dict[k].size():
-                            model_dict[k] = v
-                        else:
-                            print(
-                                f"mismatch for {k} size: checkpoint size {v.size()}, model size {model_dict[k].size()}"
-                            )
-                            model_dict[k]
-                            not_initialized.append(k)
-                    assert (
-                        len(not_initialized) == 1
-                    ), "only allow for last layer mismatch, found more than 1 param with mismatched shape {}".format(
-                        not_initialized
+                    ckpt_keys, model_keys = set(state_dict), set(model_dict)
+
+                    mismatched = sorted(
+                        k
+                        for k in (ckpt_keys & model_keys)
+                        if state_dict[k].size() != model_dict[k].size()
                     )
+                    missing = sorted(model_keys - ckpt_keys)  # in model, not ckpt
+                    unexpected = sorted(ckpt_keys - model_keys)  # in ckpt, not model
+
+                    allowed = self._output_head_keys(net, model_keys)
+                    offenders = sorted(
+                        (set(mismatched) | set(missing) | set(unexpected)) - allowed
+                    )
+                    if offenders:
+                        raise RuntimeError(
+                            f"Refusing to partially load '{load_path}': checkpoint "
+                            f"incompatible on non-output-head params: {offenders}. "
+                            f"Usually a different architecture / config -- e.g. a "
+                            f"different --primus_num_register_tokens, which reshapes "
+                            f"eva.pos_embed. Load a matching checkpoint or start fresh. "
+                            f"(shape-mismatched={mismatched}, missing_from_ckpt={missing}, "
+                            f"unexpected_in_ckpt={unexpected})"
+                        ) from e
+
+                    # Only output-head params differ: copy every shape-matching
+                    # tensor and leave the output head at its fresh init.
+                    for k in ckpt_keys & model_keys:
+                        if state_dict[k].size() == model_dict[k].size():
+                            model_dict[k] = state_dict[k]
                     net.load_state_dict(model_dict)
-                    print("Partial network initialized")
+                    print(
+                        f"Partial load from '{load_path}': reinitialized output-head "
+                        f"params {sorted(set(mismatched) | set(missing))} (left at fresh "
+                        f"init); all other weights loaded."
+                    )
 
     def load_G_only(self, ckpt_path):
         """Warm-start only the base network (netG) from a standalone .pth file.

--- a/pretraining/models/base_model.py
+++ b/pretraining/models/base_model.py
@@ -265,7 +265,20 @@ class BaseModel(ABC):
                     torch.save(net.cpu().state_dict(), save_path)
 
     def _output_head_keys(self, net, keys):
-        """Return output-head keys that a partial warm start may reinitialize."""
+        """Find output-head keys that a partial warm start may reinitialize.
+
+        Parameters
+        ----------
+        net : torch.nn.Module
+            Base network, optionally wrapped by compile or DataParallel.
+        keys : iterable of str
+            State-dict keys to inspect.
+
+        Returns
+        -------
+        set of str
+            Keys belonging to the network's output head.
+        """
         core = getattr(net, "_orig_mod", net)  # unwrap torch.compile
         core = getattr(core, "module", core)   # unwrap DataParallel
 

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -63,7 +63,8 @@ def define_G(
     gpu_ids : list of int, optional
         Which GPUs the network runs on. Default is [].
     opt : object, optional
-        Additional architecture options.
+        Additional architecture options. Primus requires ``crop_size`` and the
+        fields registered by ``add_primus_arguments``.
     final_act : str, optional
         Final activation function. Default is 'none'.
     activation : str, optional
@@ -74,6 +75,8 @@ def define_G(
         Interpolation type. Default is 'nearest'.
     num_downs : int, optional
         Number of downsamples in encoder. Default is 4.
+    norm_eps : float, optional
+        Numerical-stability epsilon for UNet normalization layers.
 
     Returns
     -------

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -11,6 +11,7 @@ from anatomix.model.network import (
     get_actvn_layer,
     get_norm_layer,
 )
+from anatomix.model import PRIMUS_CONFIGS, Primus, PrimusV2
 
 
 # -------------------------------
@@ -100,6 +101,55 @@ def define_G(
             pooling=pooling,
             interp=interp,
             norm_eps=norm_eps,
+        )
+    elif netG == "primus":
+        # 3D ViT: forward returns a dense (B, output_nc, D, H, W) map -- the same
+        # contract as the UNet output -- so it plugs into the contrastive machinery.
+        ps = opt.primus_patch_size
+        cs = opt.crop_size
+        assert cs % ps == 0, (
+            "crop_size (%d) must be divisible by primus_patch_size (%d)" % (cs, ps)
+        )
+        v2 = opt.primus_version == "v2"
+        assert not (v2 and ps != 8), (
+            "PrimusV2's deeper patch embed is hardwired to an 8x stride; "
+            "use --primus_patch_size 8 with --primus_version v2"
+        )
+        nreg = opt.primus_num_register_tokens
+        assert nreg >= 0, (
+            "primus_num_register_tokens must be >= 0 (got %d)" % nreg
+        )
+        # Build the vendored v1 (Primus) / v2 (PrimusV2) from anatomix/model/vit3d,
+        # applying the stability tricks init_values=0.1 (LayerScale) and
+        # scale_attn_inner=True. The defaults (num_register_tokens=0, in_eps=1e-5)
+        # match the official state_dict, so existing checkpoints still load.
+        conf = PRIMUS_CONFIGS[opt.primus_config]
+        kwargs = dict(
+            input_channels=input_nc,
+            num_classes=output_nc,
+            embed_dim=conf["embed_dim"],
+            eva_depth=conf["eva_depth"],
+            eva_numheads=conf["eva_numheads"],
+            patch_embed_size=(ps, ps, ps),
+            input_shape=(cs, cs, cs),
+            drop_path_rate=opt.primus_drop_path_rate,
+            num_register_tokens=nreg,
+            init_values=0.1,
+            scale_attn_inner=True,
+            # Stability knobs (see anatomix/model/vit3d build_out_norm): QK-norm,
+            # output spatial norm (out_norm_eps = --primus_v2_in_eps), register init.
+            qk_norm=opt.primus_qk_norm,
+            out_norm=opt.primus_out_norm,
+            out_norm_eps=opt.primus_v2_in_eps,
+            register_init_std=opt.primus_register_init_std,
+        )
+        if v2:
+            net = PrimusV2(in_eps=opt.primus_v2_in_eps, **kwargs)
+        else:
+            net = Primus(**kwargs)
+        # ViT self-initializes; initialize_weights=False so init_net doesn't clobber it.
+        return init_net(
+            net, init_type, init_gain, gpu_ids, initialize_weights=False
         )
     else:
         raise NotImplementedError(

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -50,7 +50,7 @@ def define_G(
     ngf : int
         Number of filters in the first conv layer.
     netG : str
-        The architecture's name: 'unet'.
+        Base architecture: 'unet' or 'primus'.
     norm : str, optional
         The name of normalization layers used in the network: 'batch' | 'instance' | 'none'.
         Default is 'batch'.
@@ -63,7 +63,7 @@ def define_G(
     gpu_ids : list of int, optional
         Which GPUs the network runs on. Default is [].
     opt : object, optional
-        Additional options (not used here).
+        Additional architecture options.
     final_act : str, optional
         Final activation function. Default is 'none'.
     activation : str, optional

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -119,7 +119,7 @@ def define_G(
         assert nreg >= 0, (
             "primus_num_register_tokens must be >= 0 (got %d)" % nreg
         )
-        # Build the vendored v1 (Primus) / v2 (PrimusV2) from anatomix/model/vit3d,
+        # Build the local v1 (Primus) / v2 (PrimusV2) ViT from anatomix/model/vit3d,
         # applying the stability tricks init_values=0.1 (LayerScale) and
         # scale_attn_inner=True. The defaults (num_register_tokens=0, in_eps=1e-5)
         # match the official state_dict, so existing checkpoints still load.

--- a/pretraining/models/pretraining_networks.py
+++ b/pretraining/models/pretraining_networks.py
@@ -11,7 +11,6 @@ from anatomix.model.network import (
     get_actvn_layer,
     get_norm_layer,
 )
-from anatomix.model import PRIMUS_CONFIGS, Primus, PrimusV2
 
 
 # -------------------------------
@@ -103,8 +102,8 @@ def define_G(
             norm_eps=norm_eps,
         )
     elif netG == "primus":
-        # 3D ViT: forward returns a dense (B, output_nc, D, H, W) map -- the same
-        # contract as the UNet output -- so it plugs into the contrastive machinery.
+        from anatomix.model.vit3d import PRIMUS_CONFIGS, Primus, PrimusV2
+
         ps = opt.primus_patch_size
         cs = opt.crop_size
         assert cs % ps == 0, (
@@ -119,10 +118,6 @@ def define_G(
         assert nreg >= 0, (
             "primus_num_register_tokens must be >= 0 (got %d)" % nreg
         )
-        # Build the local v1 (Primus) / v2 (PrimusV2) ViT from anatomix/model/vit3d,
-        # applying the stability tricks init_values=0.1 (LayerScale) and
-        # scale_attn_inner=True. The defaults (num_register_tokens=0, in_eps=1e-5)
-        # match the official state_dict, so existing checkpoints still load.
         conf = PRIMUS_CONFIGS[opt.primus_config]
         kwargs = dict(
             input_channels=input_nc,
@@ -136,8 +131,6 @@ def define_G(
             num_register_tokens=nreg,
             init_values=0.1,
             scale_attn_inner=True,
-            # Stability knobs (see anatomix/model/vit3d build_out_norm): QK-norm,
-            # output spatial norm (out_norm_eps = --primus_v2_in_eps), register init.
             qk_norm=opt.primus_qk_norm,
             out_norm=opt.primus_out_norm,
             out_norm_eps=opt.primus_v2_in_eps,
@@ -147,7 +140,6 @@ def define_G(
             net = PrimusV2(in_eps=opt.primus_v2_in_eps, **kwargs)
         else:
             net = Primus(**kwargs)
-        # ViT self-initializes; initialize_weights=False so init_net doesn't clobber it.
         return init_net(
             net, init_type, init_gain, gpu_ids, initialize_weights=False
         )

--- a/pretraining/models/supcl_model.py
+++ b/pretraining/models/supcl_model.py
@@ -398,7 +398,22 @@ class SupCLModel(BaseModel):
                 ]
             else:
                 self.nce_weights = []
+        # nce_layers and nce_weights must align; mismatched lengths are a user
+        # error and should fail loudly (enforced for every architecture).
         assert len(self.nce_weights) == len(self.nce_layers)
+
+        # The 3D ViT is single-resolution (one token grid; only the decoder
+        # upsamples), so NCE runs on its single final feature map. The CLI
+        # nce_layers/nce_weights (which index UNet layers) are validated above but
+        # forced to a single entry here; -1 is just the log label (forward()
+        # bypasses nce_layers for this path).
+        if opt.netG == "primus":
+            self.nce_layers = [-1]
+            self.nce_weights = [1.0]
+            self.last_layer_to_freeze = -1
+            print(
+                "3D ViT: single-scale NCE on the final feature map (logged as layer -1)"
+            )
 
         self.use_mask = opt.load_mask
 
@@ -553,8 +568,18 @@ class SupCLModel(BaseModel):
                 self.label_subjid = self.label_subjid[:bs_per_gpu]
                 """
 
-                self.forward(verbose=False)
-                self.compute_G_loss(0).backward()
+                # autocast (matching optimize_parameters) so this one-off init
+                # fwd/bwd doesn't OOM in fp32 for large ViT configs. The init
+                # backward is throwaway (grads zeroed before the first real step),
+                # so it's inert and harmless for the UNet path too.
+                if torch.cuda.is_bf16_supported():
+                    amp_dtype = torch.bfloat16
+                else:
+                    amp_dtype = torch.float16
+                with torch.amp.autocast(device_type="cuda", dtype=amp_dtype):
+                    self.forward(verbose=False)
+                    loss_G = self.compute_G_loss(0)
+                loss_G.backward()
                 if (
                     self.opt.lambda_NCE > 0.0
                     and self.opt.use_mlp
@@ -716,9 +741,14 @@ class SupCLModel(BaseModel):
                 self.reals = self.real_A
 
             # Forward pass through base network with NCE layers
-            segs, self.feat_kq = self.netG(
-                self.reals, self.nce_layers, False, verbose=verbose
-            )
+            if self.opt.netG == "primus":
+                # 3D ViT returns one dense feature map = the sole NCE feature.
+                segs = self.netG(self.reals)
+                self.feat_kq = [segs]
+            else:
+                segs, self.feat_kq = self.netG(
+                    self.reals, self.nce_layers, False, verbose=verbose
+                )
 
             # Split predictions for A and B
             self.pred_A = segs[: self.real_A.size(0)]

--- a/pretraining/models/supcl_model.py
+++ b/pretraining/models/supcl_model.py
@@ -398,15 +398,9 @@ class SupCLModel(BaseModel):
                 ]
             else:
                 self.nce_weights = []
-        # nce_layers and nce_weights must align; mismatched lengths are a user
-        # error and should fail loudly (enforced for every architecture).
         assert len(self.nce_weights) == len(self.nce_layers)
 
-        # The 3D ViT is single-resolution (one token grid; only the decoder
-        # upsamples), so NCE runs on its single final feature map. The CLI
-        # nce_layers/nce_weights (which index UNet layers) are validated above but
-        # forced to a single entry here; -1 is just the log label (forward()
-        # bypasses nce_layers for this path).
+        # Primus exposes one feature scale for NCE.
         if opt.netG == "primus":
             self.nce_layers = [-1]
             self.nce_weights = [1.0]
@@ -568,15 +562,17 @@ class SupCLModel(BaseModel):
                 self.label_subjid = self.label_subjid[:bs_per_gpu]
                 """
 
-                # autocast (matching optimize_parameters) so this one-off init
-                # fwd/bwd doesn't OOM in fp32 for large ViT configs. The init
-                # backward is throwaway (grads zeroed before the first real step),
-                # so it's inert and harmless for the UNet path too.
-                if torch.cuda.is_bf16_supported():
-                    amp_dtype = torch.bfloat16
+                if self.opt.netG == "primus":
+                    # Large Primus configs need the same autocast used for training.
+                    amp_dtype = (
+                        torch.bfloat16
+                        if torch.cuda.is_bf16_supported()
+                        else torch.float16
+                    )
+                    with torch.amp.autocast(device_type="cuda", dtype=amp_dtype):
+                        self.forward(verbose=False)
+                        loss_G = self.compute_G_loss(0)
                 else:
-                    amp_dtype = torch.float16
-                with torch.amp.autocast(device_type="cuda", dtype=amp_dtype):
                     self.forward(verbose=False)
                     loss_G = self.compute_G_loss(0)
                 loss_G.backward()
@@ -741,14 +737,9 @@ class SupCLModel(BaseModel):
                 self.reals = self.real_A
 
             # Forward pass through base network with NCE layers
-            if self.opt.netG == "primus":
-                # 3D ViT returns one dense feature map = the sole NCE feature.
-                segs = self.netG(self.reals)
-                self.feat_kq = [segs]
-            else:
-                segs, self.feat_kq = self.netG(
-                    self.reals, self.nce_layers, False, verbose=verbose
-                )
+            segs, self.feat_kq = self.netG(
+                self.reals, self.nce_layers, False, verbose=verbose
+            )
 
             # Split predictions for A and B
             self.pred_A = segs[: self.real_A.size(0)]

--- a/pretraining/options/base_options.py
+++ b/pretraining/options/base_options.py
@@ -5,6 +5,31 @@ import models
 import data
 
 
+def primus_out_norm_mode(v):
+    """Parse ``--primus_out_norm`` to none|instance|demean|layernorm|layernorm_affine
+    (see anatomix/model/vit3d build_out_norm). Bools accepted: true->instance,
+    false->none."""
+    s = str(v).strip().lower()
+    if s in ("instance", "instancenorm", "in"):
+        return "instance"
+    if s in ("demean", "center"):
+        return "demean"
+    if s in ("layernorm", "layer", "ln"):
+        return "layernorm"
+    if s in ("layernorm_affine", "layernorm-affine", "ln_affine"):
+        return "layernorm_affine"
+    if s in ("none", "identity", "off"):
+        return "none"
+    if s in ("true", "t", "yes", "y", "1"):
+        return "instance"
+    if s in ("false", "f", "no", "n", "0"):
+        return "none"
+    raise argparse.ArgumentTypeError(
+        "expected one of none|instance|demean|layernorm|layernorm_affine (or a bool); "
+        "got %r" % v
+    )
+
+
 class BaseOptions:
     """This class defines options used during both training and test time.
 
@@ -99,8 +124,79 @@ class BaseOptions:
             "--netG",
             type=str,
             default="unet",
-            choices=["noiseunet", "noskipunet", "unet"],
+            choices=["noiseunet", "noskipunet", "unet", "primus"],
             help="specify base network architecture",
+        )
+        # 3D ViT parameters; only used when --netG primus
+        parser.add_argument(
+            "--primus_version",
+            type=str,
+            default="v1",
+            choices=["v1", "v2"],
+            help="v1 (single-conv patch embed) or v2 (deeper residual patch embed; "
+            "v2 requires --primus_patch_size 8).",
+        )
+        parser.add_argument(
+            "--primus_config",
+            type=str,
+            default="B",
+            choices=["S", "B", "M", "L"],
+            help="ViT scale: depth/heads/embed_dim.",
+        )
+        parser.add_argument(
+            "--primus_patch_size",
+            type=int,
+            default=8,
+            help="Tokenizer patch size (isotropic); crop_size must be divisible by "
+            "it. v2 requires 8.",
+        )
+        parser.add_argument(
+            "--primus_drop_path_rate",
+            type=float,
+            default=0.0,
+            help="Stochastic-depth (DropPath) rate.",
+        )
+        parser.add_argument(
+            "--primus_num_register_tokens",
+            type=int,
+            default=0,
+            help="Number of ViT register tokens; 0 (default) disables them. Only "
+            "used when --netG primus.",
+        )
+        parser.add_argument(
+            "--primus_v2_in_eps",
+            type=float,
+            default=1e-5,
+            help="InstanceNorm3d eps in the v2 deeper tokenizer (v2 only; default "
+            "1e-5 matches upstream). Also used as the --primus_out_norm eps.",
+        )
+        parser.add_argument(
+            "--primus_qk_norm",
+            type=util.str2bool,
+            nargs="?",
+            const=True,
+            default=False,
+            help="Enable QK-norm (per-head LayerNorm on q,k) in the ViT attention. "
+            "Adds eva.blocks.*.attn.{q,k}_norm params (changes the state_dict).",
+        )
+        parser.add_argument(
+            "--primus_out_norm",
+            type=primus_out_norm_mode,
+            nargs="?",
+            const="instance",
+            default="none",
+            choices=["none", "instance", "demean", "layernorm", "layernorm_affine"],
+            help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
+            "(see anatomix/model/vit3d build_out_norm; eps = --primus_v2_in_eps). Only "
+            "layernorm_affine adds params. Bare --primus_out_norm = instance; bools "
+            "accepted (true->instance, false->none).",
+        )
+        parser.add_argument(
+            "--primus_register_init_std",
+            type=float,
+            default=0.02,
+            help="Init std for register tokens (upstream 1e-6). Only used when "
+            "--primus_num_register_tokens > 0.",
         )
         parser.add_argument(
             "--normG",

--- a/pretraining/options/base_options.py
+++ b/pretraining/options/base_options.py
@@ -4,30 +4,7 @@ from util import util
 import models
 import data
 
-
-def primus_out_norm_mode(v):
-    """Parse ``--primus_out_norm`` to none|instance|demean|layernorm|layernorm_affine
-    (see anatomix/model/vit3d build_out_norm). Bools accepted: true->instance,
-    false->none."""
-    s = str(v).strip().lower()
-    if s in ("instance", "instancenorm", "in"):
-        return "instance"
-    if s in ("demean", "center"):
-        return "demean"
-    if s in ("layernorm", "layer", "ln"):
-        return "layernorm"
-    if s in ("layernorm_affine", "layernorm-affine", "ln_affine"):
-        return "layernorm_affine"
-    if s in ("none", "identity", "off"):
-        return "none"
-    if s in ("true", "t", "yes", "y", "1"):
-        return "instance"
-    if s in ("false", "f", "no", "n", "0"):
-        return "none"
-    raise argparse.ArgumentTypeError(
-        "expected one of none|instance|demean|layernorm|layernorm_affine (or a bool); "
-        "got %r" % v
-    )
+from .primus_options import add_primus_arguments
 
 
 class BaseOptions:
@@ -127,77 +104,9 @@ class BaseOptions:
             choices=["noiseunet", "noskipunet", "unet", "primus"],
             help="specify base network architecture",
         )
-        # 3D ViT parameters; only used when --netG primus
-        parser.add_argument(
-            "--primus_version",
-            type=str,
-            default="v1",
-            choices=["v1", "v2"],
-            help="v1 (single-conv patch embed) or v2 (deeper residual patch embed; "
-            "v2 requires --primus_patch_size 8).",
-        )
-        parser.add_argument(
-            "--primus_config",
-            type=str,
-            default="B",
-            choices=["S", "B", "M", "L"],
-            help="ViT scale: depth/heads/embed_dim.",
-        )
-        parser.add_argument(
-            "--primus_patch_size",
-            type=int,
-            default=8,
-            help="Tokenizer patch size (isotropic); crop_size must be divisible by "
-            "it. v2 requires 8.",
-        )
-        parser.add_argument(
-            "--primus_drop_path_rate",
-            type=float,
-            default=0.0,
-            help="Stochastic-depth (DropPath) rate.",
-        )
-        parser.add_argument(
-            "--primus_num_register_tokens",
-            type=int,
-            default=0,
-            help="Number of ViT register tokens; 0 (default) disables them. Only "
-            "used when --netG primus.",
-        )
-        parser.add_argument(
-            "--primus_v2_in_eps",
-            type=float,
-            default=1e-5,
-            help="InstanceNorm3d eps in the v2 deeper tokenizer (v2 only; default "
-            "1e-5 matches upstream). Also used as the --primus_out_norm eps.",
-        )
-        parser.add_argument(
-            "--primus_qk_norm",
-            type=util.str2bool,
-            nargs="?",
-            const=True,
-            default=False,
-            help="Enable QK-norm (per-head LayerNorm on q,k) in the ViT attention. "
-            "Adds eva.blocks.*.attn.{q,k}_norm params (changes the state_dict).",
-        )
-        parser.add_argument(
-            "--primus_out_norm",
-            type=primus_out_norm_mode,
-            nargs="?",
-            const="instance",
-            default="none",
-            choices=["none", "instance", "demean", "layernorm", "layernorm_affine"],
-            help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
-            "(see anatomix/model/vit3d build_out_norm; eps = --primus_v2_in_eps). Only "
-            "layernorm_affine adds params. Bare --primus_out_norm = instance; bools "
-            "accepted (true->instance, false->none).",
-        )
-        parser.add_argument(
-            "--primus_register_init_std",
-            type=float,
-            default=0.02,
-            help="Init std for register tokens (upstream 1e-6). Only used when "
-            "--primus_num_register_tokens > 0.",
-        )
+        # 3D ViT (Primus) parameters; only used when --netG primus. Kept in a
+        # separate module so this core CLI stays readable (see primus_options.py).
+        parser = add_primus_arguments(parser)
         parser.add_argument(
             "--normG",
             type=str,

--- a/pretraining/options/base_options.py
+++ b/pretraining/options/base_options.py
@@ -104,8 +104,6 @@ class BaseOptions:
             choices=["noiseunet", "noskipunet", "unet", "primus"],
             help="specify base network architecture",
         )
-        # 3D ViT (Primus) parameters; only used when --netG primus. Kept in a
-        # separate module so this core CLI stays readable (see primus_options.py).
         parser = add_primus_arguments(parser)
         parser.add_argument(
             "--normG",

--- a/pretraining/options/primus_options.py
+++ b/pretraining/options/primus_options.py
@@ -1,0 +1,110 @@
+"""Primus (3D ViT) command-line arguments.
+
+Split out of ``base_options.py`` so the core CLI stays readable; every option
+here is only consulted when ``--netG primus``. ``add_primus_arguments`` is
+called once from ``BaseOptions.initialize``.
+"""
+import argparse
+
+from util import util
+
+
+def primus_out_norm_mode(v):
+    """Parse ``--primus_out_norm`` to none|instance|demean|layernorm|layernorm_affine
+    (see anatomix/model/vit3d build_out_norm). Bools accepted: true->instance,
+    false->none."""
+    s = str(v).strip().lower()
+    if s in ("instance", "instancenorm", "in"):
+        return "instance"
+    if s in ("demean", "center"):
+        return "demean"
+    if s in ("layernorm", "layer", "ln"):
+        return "layernorm"
+    if s in ("layernorm_affine", "layernorm-affine", "ln_affine"):
+        return "layernorm_affine"
+    if s in ("none", "identity", "off"):
+        return "none"
+    if s in ("true", "t", "yes", "y", "1"):
+        return "instance"
+    if s in ("false", "f", "no", "n", "0"):
+        return "none"
+    raise argparse.ArgumentTypeError(
+        "expected one of none|instance|demean|layernorm|layernorm_affine (or a bool); "
+        "got %r" % v
+    )
+
+
+def add_primus_arguments(parser):
+    """Register the ``--primus_*`` 3D ViT options on ``parser`` and return it.
+    Only used when ``--netG primus``."""
+    parser.add_argument(
+        "--primus_version",
+        type=str,
+        default="v1",
+        choices=["v1", "v2"],
+        help="v1 (single-conv patch embed) or v2 (deeper residual patch embed; "
+        "v2 requires --primus_patch_size 8).",
+    )
+    parser.add_argument(
+        "--primus_config",
+        type=str,
+        default="B",
+        choices=["S", "B", "M", "L"],
+        help="ViT scale: depth/heads/embed_dim.",
+    )
+    parser.add_argument(
+        "--primus_patch_size",
+        type=int,
+        default=8,
+        help="Tokenizer patch size (isotropic); crop_size must be divisible by "
+        "it. v2 requires 8.",
+    )
+    parser.add_argument(
+        "--primus_drop_path_rate",
+        type=float,
+        default=0.0,
+        help="Stochastic-depth (DropPath) rate.",
+    )
+    parser.add_argument(
+        "--primus_num_register_tokens",
+        type=int,
+        default=0,
+        help="Number of ViT register tokens; 0 (default) disables them. Only "
+        "used when --netG primus.",
+    )
+    parser.add_argument(
+        "--primus_v2_in_eps",
+        type=float,
+        default=1e-5,
+        help="InstanceNorm3d eps in the v2 deeper tokenizer (v2 only; default "
+        "1e-5 matches upstream). Also used as the --primus_out_norm eps.",
+    )
+    parser.add_argument(
+        "--primus_qk_norm",
+        type=util.str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Enable QK-norm (per-head LayerNorm on q,k) in the ViT attention. "
+        "Adds eva.blocks.*.attn.{q,k}_norm params (changes the state_dict).",
+    )
+    parser.add_argument(
+        "--primus_out_norm",
+        type=primus_out_norm_mode,
+        nargs="?",
+        const="instance",
+        default="none",
+        choices=["none", "instance", "demean", "layernorm", "layernorm_affine"],
+        help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
+        "(see anatomix/model/vit3d build_out_norm; eps = --primus_v2_in_eps). Only "
+        "layernorm_affine adds params. Bare --primus_out_norm = instance; bools "
+        "accepted (true->instance, false->none).",
+    )
+    parser.add_argument(
+        "--primus_register_init_std",
+        type=float,
+        default=0.02,
+        help="Init std for register tokens (upstream 1e-6). Only used when "
+        "--primus_num_register_tokens > 0.",
+    )
+    return parser

--- a/pretraining/options/primus_options.py
+++ b/pretraining/options/primus_options.py
@@ -5,7 +5,18 @@ from util import util
 
 
 def primus_out_norm_mode(v):
-    """Parse output normalization names and legacy boolean values."""
+    """Parse an output-normalization name or legacy boolean value.
+
+    Parameters
+    ----------
+    v : object
+        Value supplied by argparse.
+
+    Returns
+    -------
+    str
+        Canonical normalization mode.
+    """
     s = str(v).strip().lower()
     if s in ("instance", "instancenorm", "in"):
         return "instance"
@@ -28,7 +39,18 @@ def primus_out_norm_mode(v):
 
 
 def add_primus_arguments(parser):
-    """Add Primus options to an argument parser."""
+    """Add Primus options to an argument parser.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        Parser to extend.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The same parser with Primus arguments registered.
+    """
     parser.add_argument(
         "--primus_version",
         type=str,

--- a/pretraining/options/primus_options.py
+++ b/pretraining/options/primus_options.py
@@ -1,18 +1,11 @@
-"""Primus (3D ViT) command-line arguments.
-
-Split out of ``base_options.py`` so the core CLI stays readable; every option
-here is only consulted when ``--netG primus``. ``add_primus_arguments`` is
-called once from ``BaseOptions.initialize``.
-"""
+"""Command-line options for Primus models."""
 import argparse
 
 from util import util
 
 
 def primus_out_norm_mode(v):
-    """Parse ``--primus_out_norm`` to none|instance|demean|layernorm|layernorm_affine
-    (see anatomix/model/vit3d build_out_norm). Bools accepted: true->instance,
-    false->none."""
+    """Parse output normalization names and legacy boolean values."""
     s = str(v).strip().lower()
     if s in ("instance", "instancenorm", "in"):
         return "instance"
@@ -35,8 +28,7 @@ def primus_out_norm_mode(v):
 
 
 def add_primus_arguments(parser):
-    """Register the ``--primus_*`` 3D ViT options on ``parser`` and return it.
-    Only used when ``--netG primus``."""
+    """Add Primus options to an argument parser."""
     parser.add_argument(
         "--primus_version",
         type=str,

--- a/pretraining/options/primus_options.py
+++ b/pretraining/options/primus_options.py
@@ -64,7 +64,8 @@ def add_primus_arguments(parser):
         type=str,
         default="B",
         choices=["S", "B", "M", "L"],
-        help="ViT scale: depth/heads/embed_dim.",
+        help="ViT scale as depth/heads/embedding width: S=12/6/396, "
+        "B=12/12/792, M=16/12/864, or L=24/16/1056.",
     )
     parser.add_argument(
         "--primus_patch_size",
@@ -77,14 +78,15 @@ def add_primus_arguments(parser):
         "--primus_drop_path_rate",
         type=float,
         default=0.0,
-        help="Stochastic-depth (DropPath) rate.",
+        help="Maximum probability of skipping a transformer block during "
+        "training; 0 disables stochastic depth.",
     )
     parser.add_argument(
         "--primus_num_register_tokens",
         type=int,
         default=0,
-        help="Number of ViT register tokens; 0 (default) disables them. Only "
-        "used when --netG primus.",
+        help="Number of learned tokens included in attention but discarded "
+        "before decoding; 0 disables them.",
     )
     parser.add_argument(
         "--primus_v2_in_eps",
@@ -109,10 +111,10 @@ def add_primus_arguments(parser):
         const="instance",
         default="none",
         choices=["none", "instance", "demean", "layernorm", "layernorm_affine"],
-        help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
-        "(see anatomix/model/vit3d build_out_norm; eps = --primus_v2_in_eps). Only "
-        "layernorm_affine adds params. Bare --primus_out_norm = instance; bools "
-        "accepted (true->instance, false->none).",
+        help="Decoded-volume norm: instance/demean operate spatially per "
+        "channel; layernorm modes operate across channels per voxel; none "
+        "disables. Only layernorm_affine adds parameters. A bare flag or true "
+        "selects instance; false selects none. Uses --primus_v2_in_eps.",
     )
     parser.add_argument(
         "--primus_register_init_std",

--- a/pretraining/scripts/pretrain_anatomix.py
+++ b/pretraining/scripts/pretrain_anatomix.py
@@ -1,7 +1,11 @@
 import argparse
+import os
 import subprocess
 import sys
 import shlex
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from options.primus_options import add_primus_arguments
 
 
 def main(args):
@@ -436,65 +440,6 @@ if __name__ == "__main__":
         "(inverse sqrt counts, a softer correction). No effect unless one of "
         "those flags is set.",
     )
-    # 3D ViT params; only used when --netG primus
-    parser.add_argument(
-        "--primus_version",
-        type=str,
-        default="v1",
-        choices=["v1", "v2"],
-        help="v1 (single-conv patch embed) or v2 (deeper residual; requires "
-        "--primus_patch_size 8)",
-    )
-    parser.add_argument(
-        "--primus_config",
-        type=str,
-        default="B",
-        choices=["S", "B", "M", "L"],
-        help="ViT scale (depth/heads/embed_dim)",
-    )
-    parser.add_argument(
-        "--primus_patch_size",
-        type=int,
-        default=8,
-        help="Tokenizer patch size (crop_size must be divisible by it)",
-    )
-    parser.add_argument(
-        "--primus_drop_path_rate",
-        type=float,
-        default=0.0,
-        help="Stochastic-depth (DropPath) rate",
-    )
-    parser.add_argument(
-        "--primus_num_register_tokens",
-        type=int,
-        default=0,
-        help="Number of ViT register tokens (0 disables; only for --netG primus)",
-    )
-    parser.add_argument(
-        "--primus_v2_in_eps",
-        type=float,
-        default=1e-5,
-        help="v2 deeper-tokenizer InstanceNorm3d eps (v2 only); also the "
-        "--primus_out_norm eps",
-    )
-    parser.add_argument(
-        "--primus_qk_norm",
-        type=str,
-        default="False",
-        help="Enable QK-norm in the ViT attention. Only for --netG primus.",
-    )
-    parser.add_argument(
-        "--primus_out_norm",
-        type=str,
-        default="False",
-        help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
-        "(eps = --primus_v2_in_eps). Only for --netG primus.",
-    )
-    parser.add_argument(
-        "--primus_register_init_std",
-        type=float,
-        default=0.02,
-        help="Init std for register tokens (upstream 1e-6).",
-    )
+    parser = add_primus_arguments(parser)
     args = parser.parse_args()
     main(args)

--- a/pretraining/scripts/pretrain_anatomix.py
+++ b/pretraining/scripts/pretrain_anatomix.py
@@ -64,6 +64,15 @@ def main(args):
         "--weigh_rarity", str(args.weigh_rarity),
         "--balance_denominator", str(args.balance_denominator),
         "--weighting_mode", args.weighting_mode,
+        "--primus_version", str(args.primus_version),
+        "--primus_config", str(args.primus_config),
+        "--primus_patch_size", str(args.primus_patch_size),
+        "--primus_drop_path_rate", str(args.primus_drop_path_rate),
+        "--primus_num_register_tokens", str(args.primus_num_register_tokens),
+        "--primus_v2_in_eps", str(args.primus_v2_in_eps),
+        "--primus_qk_norm", str(args.primus_qk_norm),
+        "--primus_out_norm", str(args.primus_out_norm),
+        "--primus_register_init_std", str(args.primus_register_init_std),
     ]
     print("Running command:\n" + " ".join(shlex.quote(x) for x in cmd))
     subprocess.run(cmd, check=True)
@@ -426,6 +435,66 @@ if __name__ == "__main__":
         "--balance_denominator: 'raw' (inverse counts, default) or 'sqrt' "
         "(inverse sqrt counts, a softer correction). No effect unless one of "
         "those flags is set.",
+    )
+    # 3D ViT params; only used when --netG primus
+    parser.add_argument(
+        "--primus_version",
+        type=str,
+        default="v1",
+        choices=["v1", "v2"],
+        help="v1 (single-conv patch embed) or v2 (deeper residual; requires "
+        "--primus_patch_size 8)",
+    )
+    parser.add_argument(
+        "--primus_config",
+        type=str,
+        default="B",
+        choices=["S", "B", "M", "L"],
+        help="ViT scale (depth/heads/embed_dim)",
+    )
+    parser.add_argument(
+        "--primus_patch_size",
+        type=int,
+        default=8,
+        help="Tokenizer patch size (crop_size must be divisible by it)",
+    )
+    parser.add_argument(
+        "--primus_drop_path_rate",
+        type=float,
+        default=0.0,
+        help="Stochastic-depth (DropPath) rate",
+    )
+    parser.add_argument(
+        "--primus_num_register_tokens",
+        type=int,
+        default=0,
+        help="Number of ViT register tokens (0 disables; only for --netG primus)",
+    )
+    parser.add_argument(
+        "--primus_v2_in_eps",
+        type=float,
+        default=1e-5,
+        help="v2 deeper-tokenizer InstanceNorm3d eps (v2 only); also the "
+        "--primus_out_norm eps",
+    )
+    parser.add_argument(
+        "--primus_qk_norm",
+        type=str,
+        default="False",
+        help="Enable QK-norm in the ViT attention. Only for --netG primus.",
+    )
+    parser.add_argument(
+        "--primus_out_norm",
+        type=str,
+        default="False",
+        help="Output spatial norm: none|instance|demean|layernorm|layernorm_affine "
+        "(eps = --primus_v2_in_eps). Only for --netG primus.",
+    )
+    parser.add_argument(
+        "--primus_register_init_std",
+        type=float,
+        default=0.02,
+        help="Init std for register tokens (upstream 1e-6).",
     )
     args = parser.parse_args()
     main(args)

--- a/pretraining/scripts/pretrain_anatomix.py
+++ b/pretraining/scripts/pretrain_anatomix.py
@@ -318,7 +318,8 @@ if __name__ == "__main__":
         "--netG",
         type=str,
         default="unet",
-        help="specify base network architecture",
+        choices=["unet", "primus"],
+        help="base network architecture",
     )
     parser.add_argument(
         "--grad_accum_iters",
@@ -368,7 +369,7 @@ if __name__ == "__main__":
         "--pretrained_G_only_ckpt",
         type=str,
         default="None",
-        help="warm-start only the base network (netG/UNet) from a specific "
+        help="warm-start only the base network (netG) from a specific "
              ".pth file; the MLP head (netF) stays randomly initialized. "
              "'None' disables.",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 nibabel
 scipy
 scikit-image
-scikit-learn
 simpleitk
 nilearn
 h5py
@@ -15,4 +14,4 @@ tensorboard
 tqdm
 natsort
 huggingface_hub
-dynamic-network-architectures
+dynamic-network-architectures==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 nibabel
 scipy
 scikit-image
+scikit-learn
 simpleitk
 nilearn
 h5py


### PR DESCRIPTION
- Porting Primus V1 and V2 from https://arxiv.org/abs/2503.01835 as an option to pretrain. Primus is roughly a 3D ViT with RoPE and learned pos embs and a transposed conv decoder. V1 tokenizes as usual and throws a bunch of self-attn layers at it. V2 has a convolutional tokenizer/encoder (hardcoded to 8x8x8 tokens in their implementation). The main difference between Primus and other 3D ViTs for medical volumes is the lack of skip connections between higher-res encoder/decoder features. 
- Added/exposed a few creature comforts that were either absent or hardcoded in the original Primus repo for the pretraining context. Stuff like QK normalization on the self-attention layers, output activation normalization options, register tokens (with tunable initialization).
- Pinned dynamic-network-architectures at 0.4.4 because the code's just importing now and the nnPeople might change their library down the line.