### PR TITLE
Add new pretrained models: 94M param 3D UNet and a 26M param 3D ViT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 #### [Colab Tutorial: 3D Feature Extraction & 3D Multimodal Registration](https://colab.research.google.com/drive/1shivu4GtUoiDzDrE9RKD1RuEm3OqXJuD?usp=sharing)
 #### [Colab Tutorial: Finetune anatomix for 3D Few-shot Segmentation with MONAI](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing)
 
-> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode (e.g. on whole body CT), it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+> **New 1**: Added experimental 94M-parameter U-Net (`anatomix-dev`) and 26M-parameter 3D ViT (`anatomix-dev-vit`) models, both of which are trained on more and better data using better pretraining losses. Make sure to voxelwise normalize their features to have either unit norm or have zero mean with unit standard deviation prior to feature visualization or use in out-of-the-box feature-based applications like registration.
 
-> **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [DropGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
+> **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [MaskGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
 
 ![Highlight collage](https://www.neeldey.com/files/anatomix_github_highlight.png)
 
@@ -39,13 +39,14 @@ Pull the model and weights from HuggingFace Hub:
 from anatomix.model.load_from_hf import load_from_hf
 
 model = load_from_hf("anatomix")          # 6M params. ICLR2025 version of the pretrained model
-# model = load_from_hf("anatomix+brains") # 6M params. Brain label augmented ICLR2025 version of the pretrained model
 ```
 
-Or **NEW** experimental model architecture and weights available here:
+Or use one of the **NEW** experimental models and weights available here:
 ```python
-model = load_from_hf("anatomix-dev")      # 36M params. Experimental model. More parameters, better features. Give it a shot.
+model = load_from_hf("anatomix-dev")        # 94M-parameter experimental UNet. More parameters, better features. Give it a shot.
+# model = load_from_hf("anatomix-dev-vit")  # 26M-parameter experimental 3D ViT. Requires 128^3 inputs, but amenable to sliding window.
 ```
+(**NOTE:** When visualizing features or when using these dev models for out-of-the-box applications like registration, make sure to voxelwise normalize the features across channels to have unit norm or zero mean with unit standard deviation, either will work.)
 
 Or just load a local checkpoint:
 
@@ -61,7 +62,7 @@ model = Unet(
     ngf=16,  # channel multiplier
 )
 
-# model = torch.compile(model)  # add if using a compiled pretrained model such as `anatomix-dev`
+# model = torch.compile(model)
 
 model.load_state_dict(
     torch.load("./model-weights/anatomix.pth"),
@@ -71,7 +72,7 @@ model.load_state_dict(
 
 See how to use it on real data for feature extraction or registration in [this tutorial](https://colab.research.google.com/drive/1shivu4GtUoiDzDrE9RKD1RuEm3OqXJuD?usp=sharing). Or if you want to finetune for your own task, check out [this tutorial](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing) instead.
 
-(If your task involves brains, you might benefit by using the `anatomix+brains` (6M) or `anatomix-dev` (36M) weights instead.)
+(If your task involves brains, abdomens, and generally interesting shapes, you might benefit from the two `anatomix-dev` models.)
 
 ## Install dependencies:
 
@@ -153,4 +154,3 @@ If you find our work useful, please consider citing:
 
 Portions of this repository have been taken from the [Contrastive Unpaired Translation](https://github.com/taesungp/contrastive-unpaired-translation) 
 and [ConvexAdam](https://github.com/multimodallearning/convexAdam) repositories and modified. Thanks!
-

--- a/anatomix/model/load_from_hf.py
+++ b/anatomix/model/load_from_hf.py
@@ -1,4 +1,4 @@
-"""Load anatomix Unet weights from the HuggingFace Hub."""
+"""Load anatomix model weights from the HuggingFace Hub."""
 import torch
 from huggingface_hub import hf_hub_download
 
@@ -7,24 +7,31 @@ from anatomix.model.network import Unet
 
 DEFAULT_REPO = "neeldey/anatomix"
 
-# Variant name -> kwargs passed to Unet.__init__. Add new entries here when a
-# new variant is published to the Hub. Any kwarg accepted by Unet is allowed.
+# Variant name -> model constructor kwargs and output width.
 ANATOMIX_VARIANTS = {
     "anatomix": {
         "unet_kwargs": dict(
             dimension=3, input_nc=1, output_nc=16, num_downs=4, ngf=16,
         ),
-    },
-    "anatomix+brains": {
-        "unet_kwargs": dict(
-            dimension=3, input_nc=1, output_nc=16, num_downs=4, ngf=16,
-        ),
+        "output_channels": 16,
     },
     "anatomix-dev": {
         "unet_kwargs": dict(
-            dimension=3, input_nc=1, output_nc=16, num_downs=5, ngf=20,
-            norm="instance", pooling="Avg", interp="trilinear",
+            dimension=3, input_nc=1, output_nc=32, num_downs=5, ngf=32,
+            norm="instance", pooling="Avg", interp="trilinear", norm_eps=1e-2,
         ),
+        "output_channels": 32,
+    },
+    "anatomix-dev-vit": {
+        "vit_kwargs": dict(
+            input_channels=1, num_classes=32, embed_dim=396, eva_depth=12,
+            eva_numheads=6, patch_embed_size=(8, 8, 8),
+            input_shape=(128, 128, 128), num_register_tokens=8,
+            init_values=0.1, scale_attn_inner=True, qk_norm=True,
+            out_norm="demean", out_norm_eps=1e-2,
+            register_init_std=0.02, in_eps=1e-2,
+        ),
+        "output_channels": 32,
     },
 }
 
@@ -49,7 +56,10 @@ def load_from_hf(
     map_location="cpu",
 ):
     """Download `<variant>.pth` from `repo_id` on the HuggingFace Hub and
-    return a Unet instantiated with the registered kwargs and weights loaded.
+    return the registered model with its weights loaded.
+
+    Checkpoints saved from ``torch.compile`` are returned as ordinary modules
+    so architecture-specific forward arguments remain available.
     """
     if variant not in ANATOMIX_VARIANTS:
         raise ValueError(
@@ -60,5 +70,10 @@ def load_from_hf(
         repo_id, f"{variant}.pth", revision=revision,
     )
     state_dict = torch.load(weights_path, map_location=map_location)
-    model = Unet(**ANATOMIX_VARIANTS[variant]["unet_kwargs"])
+    config = ANATOMIX_VARIANTS[variant]
+    if "vit_kwargs" in config:
+        from anatomix.model.vit3d import PrimusV2
+        model = PrimusV2(**config["vit_kwargs"])
+    else:
+        model = Unet(**config["unet_kwargs"])
     return _load_handling_compile(model, state_dict)

--- a/anatomix/model/load_from_hf.py
+++ b/anatomix/model/load_from_hf.py
@@ -32,10 +32,12 @@ ANATOMIX_VARIANTS = {
 def _load_handling_compile(model, state_dict):
     """Load `state_dict` into `model`, transparently handling weights saved
     from a `torch.compile()`-wrapped model (whose keys carry an `_orig_mod.`
-    prefix). The compiled wrapper is applied before loading so the structures
-    match."""
+    prefix)."""
     if state_dict and next(iter(state_dict)).startswith("_orig_mod."):
-        model = torch.compile(model)
+        state_dict = {
+            key.removeprefix("_orig_mod."): value
+            for key, value in state_dict.items()
+        }
     model.load_state_dict(state_dict, strict=True)
     return model
 

--- a/anatomix/model/network.py
+++ b/anatomix/model/network.py
@@ -465,6 +465,13 @@ class Unet(nn.Module):
         self.model = nn.Sequential(*model)
 
     def forward(self, input, layers=[], encode_only=False, verbose=False):
+        """Run ``input``, optionally collecting activations at ``layers``.
+
+        Without ``layers``, returns the network output tensor.
+        With ``layers``, returns the output tensor and a list of activations.
+        With ``encode_only``, stops early and returns only the activation list.
+        ``verbose`` prints each layer's output shape.
+        """
         if len(layers) > 0:
             feat = input
             feats = []

--- a/anatomix/registration/README.md
+++ b/anatomix/registration/README.md
@@ -4,7 +4,7 @@
 
 ![Qualitative registration collage](https://www.neeldey.com/files/qualitative-registration-v2.png)
 
-> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+> **New 1**: Added a new experimental 94M-parameter model (`anatomix-dev`), trained on even more data.
 
 The demo script in this folder extracts pretrained network features from input
 volumes and runs a registration solver on the features to align volumes
@@ -38,8 +38,8 @@ python run_convex_adam_with_network_feats.py \
 
 Or using a local checkpoint. When loading a local `.pth`, the U-Net
 architecture flags must be set to match the checkpoint that was saved.
-The values below are the defaults for the published `anatomix` and
-`anatomix+brains` weights (so they could be omitted), but they're shown
+The values below are the defaults for the published `anatomix` weights (so
+they could be omitted), but they're shown
 explicitly here because non-default checkpoints will need to override them:
 ```bash
 python run_convex_adam_with_network_feats.py \
@@ -93,7 +93,7 @@ options:
                         Path to a local .pth model checkpoint. Mutually exclusive with --hf_variant.
   --hf_variant HF_VARIANT
                         HuggingFace Hub variant to download from neeldey/anatomix
-                        (e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').
+                        (e.g. 'anatomix', 'anatomix-dev').
                         Mutually exclusive with --ckpt_path.
   --num_downs NUM_DOWNS
                         Number of downsampling layers in the U-Net. Default 4.

--- a/anatomix/registration/run_convex_adam_with_network_feats.py
+++ b/anatomix/registration/run_convex_adam_with_network_feats.py
@@ -351,7 +351,7 @@ if __name__=="__main__":
     src.add_argument(
         "--hf_variant", type=str, default=None,
         help="HuggingFace Hub variant to download from neeldey/anatomix "
-             "(e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev')."
+             "(e.g. 'anatomix', 'anatomix-dev')."
     )
     # Unet architecture kwargs. Only used with --ckpt_path; ignored for
     # --hf_variant (kwargs come from the variant registry).

--- a/anatomix/segmentation/README.md
+++ b/anatomix/segmentation/README.md
@@ -2,7 +2,7 @@
 
 ### [Colab tutorial on how to prepare data and finetune for 3D segmentation with anatomix and MONAI](https://colab.research.google.com/drive/1WBslSRLgAAMq6o5YFif1y0kaW9Ac15XK?usp=sharing)
 
-> **New 1**: Added a new experimental model (`anatomix-dev`). It is larger (36M params), trained on even more data, and has better features. If in sliding window mode, it works best with larger crops (e.g., 256^3). Try using it instead for your experiments.
+> **New 1**: Added a new experimental 94M-parameter model (`anatomix-dev`), trained on even more data.
 
 > **New 2**: Interested in using anatomix features to enhance segmentation training regardless of the test domain and how much data you have? Check out [DropGen](https://arxiv.org/abs/2604.02564), a simple 5-line modification to standard training that uses anatomix to get SOTA domain generalization.
 
@@ -60,8 +60,8 @@ python train_segmentation.py \
 
 Or using a local checkpoint. When loading a local `.pth`, the U-Net
 architecture flags must be set to match the checkpoint that was saved.
-The values below are the defaults for the published `anatomix` and
-`anatomix+brains` weights (so they could be omitted), but they're shown
+The values below are the defaults for the published `anatomix` weights (so
+they could be omitted), but they're shown
 explicitly here because non-default checkpoints will need to override them:
 ```bash
 python train_segmentation.py \
@@ -134,7 +134,7 @@ optional arguments:
                         Mutually exclusive with --hf_variant.
   --hf_variant HF_VARIANT
                         HuggingFace Hub variant to download from neeldey/anatomix
-                        (e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').
+                        (e.g. 'anatomix', 'anatomix-dev').
                         Mutually exclusive with --pretrained_ckpt.
   --num_downs NUM_DOWNS
                         Number of downsampling layers in the U-Net. Default 4.

--- a/anatomix/segmentation/segmentation_utils.py
+++ b/anatomix/segmentation/segmentation_utils.py
@@ -87,7 +87,7 @@ def load_model(
     if hf_variant is not None:
         print(f"Transferring from HuggingFace variant '{hf_variant}'.")
         model = load_from_hf(hf_variant).to(device)
-        feat_channels = ANATOMIX_VARIANTS[hf_variant]["unet_kwargs"]["output_nc"]
+        feat_channels = ANATOMIX_VARIANTS[hf_variant]["output_channels"]
     elif ckpt_path == "scratch":
         print("Training from random initialization.")
         model = Unet(

--- a/anatomix/segmentation/train_segmentation.py
+++ b/anatomix/segmentation/train_segmentation.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="HuggingFace Hub variant to download from neeldey/anatomix "
-             "(e.g. 'anatomix', 'anatomix+brains', 'anatomix-dev').",
+             "(e.g. 'anatomix', 'anatomix-dev').",
     )
     # Unet architecture kwargs. Only used with --pretrained_ckpt (or 'scratch');
     # ignored for --hf_variant (kwargs come from the variant registry).


### PR DESCRIPTION
- Added new pretrained models that can be directly pulled from huggingface:
    - `anatomix-dev` (94M): a 3D UNet that is substantially bigger, trained on much more data, and trained with a better pretraining loss. This model replaces the previous `anatomix-dev` model as it outperforms it broadly.
    - `anatomix-dev-vit` (26M): the above, but with a 3D ViT architecture instead. Due to learned pos embs on top of RoPE and an 8x8x8 tokenization, the network will perform best at 128^3.
- Fixed bug in getting intermediate activations from compiled model loaded from HF
- Removed the `anatomix+brains.pth` model (an old ICLR25 variant) as an option. Any use case that benefitted from that previously should now use one of the dev models instead.

If using the dev models, make sure to voxelwise normalize their features to have either unit L2-norm or have zero mean with unit standard deviation prior to feature visualization or use in out-of-the-box feature-based applications like registration.