### PR TITLE
Fixing issues and making QOL improvements in synthetic-data-generation 

### DIFF
--- a/synthetic-data-generation/README.md
+++ b/synthetic-data-generation/README.md
@@ -11,7 +11,7 @@ increase the `--max_workers` flag.
 
 ## One-call run through
 
-To run everything in one go: `./generate_training_data.sh`.
+To run everything in one go: `bash generate_training_data.sh`.
 
 ## Step-by-step run through
 
@@ -42,12 +42,12 @@ optional arguments:
                         Maximum number of worker processes to use (default: None, corresponding to all cores)
 ```
 
-### Generate 100 example 3D label ensembles:
+### Generate 200 example 3D label ensembles:
 
-This will generate 100 example 3D label ensembles using the downloaded TotalSegmentator labels.
+This will generate 200 example 3D label ensembles using the downloaded TotalSegmentator labels.
 
 ```bash
-python step1_generate_labels.py --n_ensembles 100 --templatedir /path/to/totalsegmentator/Totalsegmentator_dataset/
+python step1_generate_labels.py --n_ensembles 200 --templatedir /path/to/totalsegmentator/Totalsegmentator_dataset/
 ```
 
 Outputs will be saved in `./label_ensembles/` by default.
@@ -77,13 +77,13 @@ optional arguments:
                         Maximum number of workers for parallel processing (default: None, corresponding to all cores)
 ```
 
-### Generate 100 example 3D synthetic volume pairs of contrastive views:
+### Generate 200 example 3D synthetic volume pairs of contrastive views:
 
-This script will use the 100 example label ensembles generated above to generate 
+This script will use the 200 example label ensembles generated above to generate 
 paired volumes corresponding to two contrastive views:
 
 ```bash
-python step2_generate_views.py --end_idx 100
+python step2_generate_views.py --end_idx 200
 ```
 
 Output views will be saved in `./synthesized_views/` by default.
@@ -112,7 +112,7 @@ The codebase in `../pretraining/` requires the generated niftis to be written
 into a single HDF5 file containing the paired contrastive views and segmentation
 for each entry.
 
-To generate H5s for what you've generated so far in this README, using 80 volumes
+To generate H5s for what you've generated so far in this README, using 180 volumes
 for training and 20 for validation, run:
 ```bash
 python step3_generate_h5_w_segs.py --val_count 20

--- a/synthetic-data-generation/datagen_utils.py
+++ b/synthetic-data-generation/datagen_utils.py
@@ -512,9 +512,15 @@ def get_transforms():
             RandGaussianSharpend(keys=["view1"], prob=0.25),
             RandGaussianSharpend(keys=["view2"], prob=0.25),
             # Simulate much bigger voxels. MONAI does it nnUNet style, as
-            # opposed to TorchIO's (IMO better) per-axis anisotropic style:
-            RandSimulateLowResolutiond(keys=["view1"], prob=0.333),
-            RandSimulateLowResolutiond(keys=["view2"], prob=0.333),
+            # opposed to TorchIO's (IMO better) per-axis anisotropic style.
+            # `nearest-exact` over MONAI's `nearest` default as the latter drops
+            # the half-voxel offset and shifts content towards the origin:
+            RandSimulateLowResolutiond(
+                keys=["view1"], prob=0.333, downsample_mode="nearest-exact",
+            ),
+            RandSimulateLowResolutiond(
+                keys=["view2"], prob=0.333, downsample_mode="nearest-exact",
+            ),
             # Clip out negative values:
             ThresholdIntensityd(
                 keys=["view1", "view2"], above=True, threshold=0.,

--- a/synthetic-data-generation/datagen_utils.py
+++ b/synthetic-data-generation/datagen_utils.py
@@ -384,8 +384,9 @@ def sample_corruption(
     grid : torch.Tensor
         The grid tensor to which the deformation will be applied.
     arrsize : tuple of int, optional
-        The size of the 3D array representing the volume. 
-        Default is (128, 128, 128).
+        The size of the 3D array representing the volume.
+        Default is (128, 128, 128). `min_std`, `max_std` and `scales` are all
+        given in voxels at 128^3 and are rescaled to `arrsize`.
     min_std : float, optional
         The minimum standard deviation for the Perlin noise. Default is 1.0.
     max_std : float, optional
@@ -401,10 +402,18 @@ def sample_corruption(
     defsphere : torch.Tensor
         The deformed sphere as a tensor.
     """
-    # Sample a random radius and center for the foreground sphere
-    # This range of radii and centers was chosen arbitrarily
-    radius = np.random.randint(48, 72)
-    new_center = tuple(np.random.randint(-32, 32, size=3))
+    # The radii, centers, noise scales and displacement stds below are all in
+    # voxels and were chosen arbitrarily at 128^3, so scale them to `arrsize`
+    # to keep the foreground mask size-invariant.
+    size_ratio = arrsize[0] / 128
+
+    # Sample a random radius and center for the foreground sphere:
+    radius = np.random.randint(round(48 * size_ratio), round(72 * size_ratio))
+    new_center = tuple(
+        np.random.randint(
+            -round(32 * size_ratio), round(32 * size_ratio), size=3,
+        )
+    )
     
     # Generate a binary sphere with the sampled radius and center:
     initial_arr = np.abs(
@@ -418,9 +427,9 @@ def sample_corruption(
     # Let's sample noise to deform the binary sphere:
     randdef = draw_perlin_deformation(
         out_shape=(3,) + arrsize,
-        scales=scales,
-        min_std=min_std,
-        max_std=max_std,
+        scales=[noise_scale * size_ratio for noise_scale in scales],
+        min_std=min_std * size_ratio,
+        max_std=max_std * size_ratio,
     )
     
     randdef[0] = 2 * randdef[0] / (float(arrsize[0]) - 1)

--- a/synthetic-data-generation/step1_generate_labels.py
+++ b/synthetic-data-generation/step1_generate_labels.py
@@ -104,7 +104,9 @@ def generate_label_ensemble(
         # Generate a foreground mask. This mask starts off as a sphere with a
         # random center and radius and is then randomly deformed.
         # The 5 here could have been randomized too. You should try it :)
-        deformedsphere = ~sample_corruption(grid, max_std=5.).type(torch.bool) 
+        deformedsphere = ~sample_corruption(
+            grid, arrsize=(sidelen,) * 3, max_std=5.,
+        ).type(torch.bool)
         deformedspherenp = deformedsphere.cpu().numpy().squeeze()
         deformedspherenp = median(deformedspherenp)
         
@@ -207,7 +209,7 @@ def main(
     # Generate random seeds for each process
     seeds = np.random.choice(
         range(1, n_vols*10), size=n_vols, replace=False,
-    )
+    ).tolist()
     
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         futures = [
@@ -287,5 +289,6 @@ if __name__ == "__main__":
         args.min_templates,
         args.max_templates,
         args.savedir,
+        sidelen=args.side_length,
         max_workers=args.max_workers
     )

--- a/synthetic-data-generation/step2_generate_views.py
+++ b/synthetic-data-generation/step2_generate_views.py
@@ -21,7 +21,6 @@ from datagen_utils import (
 
 def process_volume(
     lab,
-    volshape,
     means_range,
     stds_range,
     perl_scales,
@@ -39,8 +38,6 @@ def process_volume(
     ----------
     lab : str
         Path to the label ensemble nifti file.
-    volshape : tuple of int
-        Shape of the volume.
     means_range : tuple of int
         Range of means for the Gaussian distributions.
     stds_range : tuple of int
@@ -79,6 +76,7 @@ def process_volume(
 
     current_label = nib.load(lab).get_fdata()
     labels = np.unique(current_label)
+    volshape = current_label.shape
 
     # Sample random means and std devs for both paired volumes:
     means1 = transform_uniform(
@@ -117,17 +115,20 @@ def process_volume(
     synthperl1 = synthview1 * (1 + perl_mult_factor * randperl_view1)
     synthperl2 = synthview2 * (1 + perl_mult_factor * randperl_view2)
     
-    # Create data dict and send to MONAI augmentation pipeline:
+    # Create data dict and send to MONAI augmentation pipeline. MONAI has always
+    # needed a leading dimension of channels, but only errors out since 1.6.0:
     inputimgs = {
-        "view1": synthperl1, "view2": synthperl2, "label": current_label,
+        "view1": synthperl1[None],
+        "view2": synthperl2[None],
+        "label": current_label,
     }
     outputs = transforms(inputimgs)
 
-    # Save synthetic volumes as nifti files:
+    # Save synthetic volumes as nifti files, dropping the channel axis again.
     # Saving as uint8 volumes to not blow up disk usage.
     nib.save(
         nib.Nifti1Image(
-            (outputs['view1'] * 255.).astype(np.uint8),
+            (outputs['view1'][0] * 255.).astype(np.uint8),
             affine=np.eye(4)
         ),
         '{}/view1/view1_{}'.format(savedir, os.path.basename(lab)),
@@ -135,7 +136,7 @@ def process_volume(
     
     nib.save(
         nib.Nifti1Image(
-            (outputs['view2'] * 255.).astype(np.uint8),
+            (outputs['view2'][0] * 255.).astype(np.uint8),
             affine=np.eye(4),
         ),
         '{}/view2/view2_{}'.format(savedir, os.path.basename(lab)),
@@ -147,7 +148,6 @@ def run(
     idx_end,
     savedir,
     label_fpaths='./label_ensembles/',
-    volshape=(128, 128, 128),
     means_range=(25, 255),
     stds_range=(5, 20),
     perl_scales=(4, 8, 16, 32),
@@ -178,8 +178,6 @@ def run(
     label_fpaths : str, optional
         Path to the directory containing label files. 
         Default ./label_ensembles/'.
-    volshape : tuple of int, optional
-        Shape of the volume. Default (128, 128, 128).
     means_range : tuple of int, optional
         Range of means for the Gaussian distributions. Default [25, 255].
     stds_range : tuple of int, optional
@@ -216,7 +214,6 @@ def run(
             executor.submit(
                 process_volume,
                 lab,
-                volshape,
                 means_range,
                 stds_range,
                 perl_scales,

--- a/synthetic-data-generation/step3_generate_h5_w_segs.py
+++ b/synthetic-data-generation/step3_generate_h5_w_segs.py
@@ -19,6 +19,10 @@ def main(args):
 
     n_total = len(view1s)
     n_val = args.val_count
+    assert 0 <= n_val < n_total, (
+        f"--val_count must be in [0, {n_total}), got {n_val}. Only {n_total} "
+        "view pairs were found, so this would leave no training samples."
+    )
     n_train = n_total - n_val
 
     # Create HDF5 file for training data


### PR DESCRIPTION
Python, PyTorch, NumPy, MONAI, etc. were all bumped up in various PRs, which broke some components of the `synthetic-data-generation` folder, so:
  - Step 1 crashed in every worker. Seeds came out of np.random.choice as np.int64, which random.seed() rejects in Python 3.11+. Fixed with .tolist().

There were some silent subtle bugs discovered by dopus as well:
- `--side_length` was never forwarded from the CLI into main(), and sample_corruption was separately hardcoded to 128³. Now it's plumbed through, and the foreground mask radius, center, noise scales, and displacement stds all scale with arrsize.
- Some MONAI augmentations were apparently silently running in 2D. Views were passed to the transform pipeline without a leading channel axis, so MONAI read the first spatial axis as channels, and every spatially coupled transform acted in-plane only. Shapes came out unchanged, so nothing ever complained. Probably doesn't matter really because pretraining uses online augmentations as well, so having some anisotropic 2D augmentations would have been fine.

Some other quality-of-life improvements:
- Now supports output sizes other than 128^3.
- RandSimulateLowResolution now downsamples with the `nearest-exact` interp mode in torch. MONAI's nearest default drops the half-voxel offset and shifts content toward the origin, whereas nearest-exact matches skimage/scipy order=0, which is correct.
